### PR TITLE
Add daily wide cleaning pipeline

### DIFF
--- a/finmind_fetcher.py
+++ b/finmind_fetcher.py
@@ -25,6 +25,7 @@ import argparse
 import datetime as dt
 import logging
 import os
+import re
 import sys
 import time
 from functools import reduce
@@ -626,6 +627,362 @@ def merge_frames(frames: Dict[str, pd.DataFrame]) -> pd.DataFrame:
     return merged
 
 
+def _read_raw_merged(path: str) -> pd.DataFrame:
+    """讀取外部提供的合併檔案。"""
+
+    if not os.path.exists(path):
+        LOGGER.warning("找不到檔案 %s，跳過清理流程。", path)
+        return pd.DataFrame()
+
+    try:
+        df = pd.read_csv(path)
+    except Exception as exc:  # pylint: disable=broad-except
+        LOGGER.error("讀取 %s 時發生錯誤: %s", path, exc)
+        return pd.DataFrame()
+
+    if df.empty:
+        LOGGER.warning("檔案 %s 為空，無資料可清理。", path)
+    return df
+
+
+def _normalize_types(df: pd.DataFrame) -> pd.DataFrame:
+    """調整日期、股票代號與數值欄位的型態。"""
+
+    if df.empty:
+        return df.copy()
+
+    normalized = df.copy()
+
+    if "date" in normalized.columns:
+        normalized["date"] = pd.to_datetime(normalized["date"], errors="coerce", utc=False)
+        try:
+            normalized["date"] = normalized["date"].dt.tz_localize(None)
+        except AttributeError:
+            pass
+    else:
+        LOGGER.warning("缺少 date 欄位，後續輸出可能不完整。")
+
+    if "stock_id" in normalized.columns:
+        normalized["stock_id"] = normalized["stock_id"].astype(str).str.strip()
+    else:
+        LOGGER.warning("缺少 stock_id 欄位，後續輸出可能不完整。")
+
+    text_like = {"date", "stock_id"}
+    text_like.update({col for col in normalized.columns if "name" in col.lower()})
+    text_like.update({col for col in normalized.columns if col.lower() in {"investor", "dataset"}})
+
+    for column in normalized.columns:
+        if column in text_like:
+            continue
+        series = normalized[column]
+        if pd.api.types.is_numeric_dtype(series):
+            continue
+        if not pd.api.types.is_object_dtype(series) and not pd.api.types.is_string_dtype(series):
+            continue
+        cleaned = series.astype(str).str.strip().replace({"": np.nan})
+        cleaned = cleaned.str.replace(",", "", regex=False)
+        numeric = pd.to_numeric(cleaned, errors="coerce")
+        if numeric.notna().any() or cleaned.eq("0").any():
+            normalized[column] = numeric
+        else:
+            normalized[column] = cleaned
+
+    return normalized
+
+
+def _extract_price_block(df: pd.DataFrame) -> pd.DataFrame:
+    """取得價量相關欄位並重新命名。"""
+
+    if df.empty:
+        return pd.DataFrame(columns=["date", "stock_id", "open", "high", "low", "close", "volume", "turnover"])
+
+    price_prefix = "taiwanstockprice_"
+    price_columns = [
+        column
+        for column in df.columns
+        if column.lower().startswith(price_prefix)
+    ]
+
+    if not price_columns:
+        LOGGER.warning("在資料中找不到台股價量欄位，僅輸出法人資料。")
+        return pd.DataFrame(columns=["date", "stock_id"])
+
+    selected_columns = [col for col in ["date", "stock_id"] if col in df.columns]
+    selected_columns.extend(price_columns)
+    price_df = df[selected_columns].copy()
+
+    rename_map = {}
+    for column in price_columns:
+        lower = column.lower()
+        if lower == "taiwanstockprice_open":
+            rename_map[column] = "open"
+        elif lower == "taiwanstockprice_high":
+            rename_map[column] = "high"
+        elif lower == "taiwanstockprice_low":
+            rename_map[column] = "low"
+        elif lower == "taiwanstockprice_close":
+            rename_map[column] = "close"
+        elif lower == "taiwanstockprice_volume":
+            rename_map[column] = "volume"
+        elif lower == "taiwanstockprice_turnover":
+            rename_map[column] = "turnover"
+
+    price_df = price_df.rename(columns=rename_map)
+
+    group_keys = [col for col in ["date", "stock_id"] if col in price_df.columns]
+    if not group_keys:
+        return price_df
+
+    agg_map = {
+        column: "first"
+        for column in price_df.columns
+        if column not in {"date", "stock_id"}
+    }
+    if agg_map:
+        price_df = price_df.groupby(group_keys, as_index=False).agg(agg_map)
+    else:
+        price_df = price_df.drop_duplicates(subset=group_keys)
+
+    return price_df
+
+
+def _find_candidate_column(df: pd.DataFrame, keywords: Iterable[str], exclude: Optional[Iterable[str]] = None) -> Optional[str]:
+    """依據關鍵字尋找最適合的欄位名稱。"""
+
+    excluded = {col.lower() for col in (exclude or [])}
+    for column in df.columns:
+        lower = column.lower()
+        if lower in excluded:
+            continue
+        for keyword in keywords:
+            key = keyword.lower()
+            if lower == key or lower.endswith(f"_{key}") or key in lower:
+                return column
+    return None
+
+
+def _build_institutional_wide(df: pd.DataFrame) -> pd.DataFrame:
+    """整理法人買賣資料為寬表。"""
+
+    empty_inst = pd.DataFrame(
+        columns=[
+            "date",
+            "stock_id",
+            "inst_foreign",
+            "inst_investment_trust",
+            "inst_dealer_self",
+            "inst_dealer_hedging",
+        ]
+    )
+
+    if df.empty:
+        return empty_inst
+
+    prefix = "taiwanstockinstitutionalinvestorsbuysell_"
+    wide_columns = [
+        column
+        for column in df.columns
+        if column.lower().startswith(prefix)
+    ]
+
+    has_long_format = _find_candidate_column(df, ["investor"]) is not None
+
+    if wide_columns:
+        if has_long_format:
+            LOGGER.warning("同時偵測到法人長表與寬表欄位，將優先使用寬表資料。")
+
+        selected = [col for col in ["date", "stock_id"] if col in df.columns]
+        selected.extend(wide_columns)
+        inst_df = df[selected].copy()
+
+        rename_map = {}
+        for column in wide_columns:
+            lower = column.lower()
+            if lower.endswith("_foreign"):
+                rename_map[column] = "inst_foreign"
+            elif lower.endswith("_investment_trust"):
+                rename_map[column] = "inst_investment_trust"
+            elif lower.endswith("_dealer_self"):
+                rename_map[column] = "inst_dealer_self"
+            elif lower.endswith("_dealer_hedging"):
+                rename_map[column] = "inst_dealer_hedging"
+
+        inst_df = inst_df.rename(columns=rename_map)
+
+        group_keys = [col for col in ["date", "stock_id"] if col in inst_df.columns]
+        agg_map = {
+            column: "sum"
+            for column in inst_df.columns
+            if column not in {"date", "stock_id"}
+        }
+        if agg_map:
+            inst_df = inst_df.groupby(group_keys, as_index=False).agg(agg_map)
+        else:
+            inst_df = inst_df.drop_duplicates(subset=group_keys)
+
+        for column in empty_inst.columns:
+            if column not in inst_df.columns:
+                inst_df[column] = np.nan
+        return inst_df[empty_inst.columns]
+
+    if not has_long_format:
+        LOGGER.warning("偵測不到法人欄位，僅輸出價量資料。")
+        return empty_inst
+
+    investor_col = _find_candidate_column(df, ["investor"])
+    net_col = _find_candidate_column(df, ["net_buy_sell", "buy_sell"])
+    buy_col = _find_candidate_column(df, ["buy"], exclude=[net_col] if net_col else None)
+    sell_col = _find_candidate_column(df, ["sell"], exclude=[net_col] if net_col else None)
+
+    if not investor_col or (not net_col and (not buy_col or not sell_col)):
+        LOGGER.warning("法人長表欄位資訊不足，無法計算淨買賣超。")
+        return empty_inst
+
+    inst_df = df[[col for col in ["date", "stock_id", investor_col] if col in df.columns]].copy()
+
+    if net_col:
+        values = pd.to_numeric(df[net_col], errors="coerce")
+    else:
+        buy_series = pd.to_numeric(df[buy_col], errors="coerce").fillna(0)
+        sell_series = pd.to_numeric(df[sell_col], errors="coerce").fillna(0)
+        values = buy_series - sell_series
+
+    inst_df["value"] = values
+    inst_df = inst_df.dropna(subset=["value"], how="all")
+
+    if inst_df.empty:
+        LOGGER.warning("法人長表計算後沒有有效數值。")
+        return empty_inst
+
+    def normalize_investor(name: object) -> str:
+        text = str(name).strip().lower()
+        text = re.sub(r"[^a-z]+", "_", text)
+        return text.strip("_")
+
+    investor_map = {
+        "foreign_investor": "inst_foreign",
+        "foreign": "inst_foreign",
+        "investment_trust": "inst_investment_trust",
+        "investmenttrust": "inst_investment_trust",
+        "dealer_self": "inst_dealer_self",
+        "dealerself": "inst_dealer_self",
+        "dealer_hedging": "inst_dealer_hedging",
+        "dealerhedging": "inst_dealer_hedging",
+    }
+
+    inst_df["inst_column"] = inst_df[investor_col].map(lambda value: investor_map.get(normalize_investor(value)))
+    inst_df = inst_df.dropna(subset=["inst_column"])
+
+    if inst_df.empty:
+        LOGGER.warning("法人長表的投資人類別無法對應至標準欄位。")
+        return empty_inst
+
+    pivot = inst_df.pivot_table(
+        index=[col for col in ["date", "stock_id"] if col in inst_df.columns],
+        columns="inst_column",
+        values="value",
+        aggfunc="sum",
+    )
+    pivot = pivot.reset_index()
+
+    pivot.columns = [
+        column if isinstance(column, str) else column[1]
+        for column in pivot.columns
+    ]
+
+    for column in empty_inst.columns:
+        if column not in pivot.columns:
+            pivot[column] = np.nan
+
+    return pivot[empty_inst.columns]
+
+
+def _merge_daily_wide(price_df: pd.DataFrame, inst_df: pd.DataFrame) -> pd.DataFrame:
+    """合併價量與法人資料，確保每天每檔僅一列。"""
+
+    base_columns = ["date", "stock_id"]
+
+    if price_df is None or price_df.empty:
+        combined = inst_df.copy()
+    elif inst_df is None or inst_df.empty:
+        combined = price_df.copy()
+    else:
+        combined = pd.merge(price_df, inst_df, on=base_columns, how="outer")
+
+    if combined.empty:
+        return combined
+
+    if "date" in combined.columns:
+        combined["date"] = pd.to_datetime(combined["date"], errors="coerce", utc=False)
+        try:
+            combined["date"] = combined["date"].dt.tz_localize(None)
+        except AttributeError:
+            pass
+
+    agg_map = {}
+    for column in combined.columns:
+        if column in base_columns:
+            continue
+        if column.startswith("inst_"):
+            agg_map[column] = "sum"
+        else:
+            agg_map[column] = "first"
+
+    if agg_map:
+        combined = combined.groupby(base_columns, as_index=False).agg(agg_map)
+    else:
+        combined = combined.drop_duplicates(subset=base_columns)
+
+    for column in [
+        "inst_foreign",
+        "inst_investment_trust",
+        "inst_dealer_self",
+        "inst_dealer_hedging",
+    ]:
+        if column not in combined.columns:
+            combined[column] = np.nan
+
+    return combined
+
+
+def _print_summary(df: pd.DataFrame) -> None:
+    """在終端機輸出摘要資訊。"""
+
+    print("=== 清理後資料摘要 ===")
+    print(f"總筆數: {len(df):,}")
+
+    if "stock_id" in df.columns:
+        print(f"股票檔數: {df['stock_id'].nunique():,}")
+    else:
+        print("股票檔數: 無 stock_id 欄位")
+
+    if "date" in df.columns:
+        date_series = pd.to_datetime(df["date"], errors="coerce")
+        if date_series.notna().any():
+            min_date = date_series.min().strftime("%Y-%m-%d")
+            max_date = date_series.max().strftime("%Y-%m-%d")
+            print(f"日期範圍: {min_date} ~ {max_date}")
+        else:
+            print("日期範圍: 無有效日期")
+    else:
+        print("日期範圍: 無 date 欄位")
+
+    print("-- 欄位缺值比例 --")
+    nan_ratio = df.isna().mean()
+    for column, ratio in nan_ratio.items():
+        print(f"{column}: {ratio:.2%}")
+
+    if df.empty:
+        print("資料為空，無樣本可顯示。")
+        return
+
+    sample_is_head = np.random.rand() < 0.5
+    label = "前 3 筆" if sample_is_head else "後 3 筆"
+    sample = df.head(3) if sample_is_head else df.tail(3)
+    print(f"-- 隨機樣本 ({label}) --")
+    print(sample.to_string(index=False))
+
+
 def parse_arguments() -> argparse.Namespace:
     """解析指令列參數。"""
 
@@ -786,6 +1143,62 @@ def main() -> None:
         save_frame(merged_df, merged_csv, merged_parquet)
     else:
         LOGGER.info("使用者設定不輸出合併寬表。")
+
+    external_merged_path = "/mnt/data/_merged.csv"
+    if os.path.exists(external_merged_path):
+        LOGGER.info("偵測到 %s，開始整理每日寬表。", external_merged_path)
+        raw_external = _read_raw_merged(external_merged_path)
+        if raw_external.empty:
+            LOGGER.warning("外部合併檔案無資料，跳過每日寬表清理。")
+        else:
+            normalized = _normalize_types(raw_external)
+            price_block = _extract_price_block(normalized)
+            inst_block = _build_institutional_wide(normalized)
+            merged_daily = _merge_daily_wide(price_block, inst_block)
+            if merged_daily.empty:
+                LOGGER.warning("合併後資料為空，無法輸出每日寬表。")
+            else:
+                merged_daily = merged_daily.sort_values(["date", "stock_id"]).reset_index(drop=True)
+
+                display_df = merged_daily.copy()
+                if "date" in display_df.columns:
+                    date_series = pd.to_datetime(display_df["date"], errors="coerce")
+                    display_df["date"] = date_series.dt.strftime("%Y-%m-%d")
+                _print_summary(display_df)
+
+                output_path = "/mnt/data/_clean_daily_wide.csv"
+                output_min_path = "/mnt/data/_clean_daily_wide_min.csv"
+
+                export_df = merged_daily.copy()
+                if "date" in export_df.columns:
+                    date_series = pd.to_datetime(export_df["date"], errors="coerce")
+                    export_df["date"] = date_series.dt.strftime("%Y-%m-%d")
+
+                required_min_columns = [
+                    "date",
+                    "stock_id",
+                    "open",
+                    "high",
+                    "low",
+                    "close",
+                    "volume",
+                    "turnover",
+                    "inst_foreign",
+                    "inst_investment_trust",
+                    "inst_dealer_self",
+                    "inst_dealer_hedging",
+                ]
+                for column in required_min_columns:
+                    if column not in export_df.columns:
+                        export_df[column] = np.nan
+
+                export_df.to_csv(output_path, index=False, encoding="utf-8")
+                export_df[required_min_columns].to_csv(
+                    output_min_path, index=False, encoding="utf-8"
+                )
+                LOGGER.info("每日寬表已輸出至 %s 與 %s。", output_path, output_min_path)
+    else:
+        LOGGER.info("未偵測到 %s，跳過每日寬表清理。", external_merged_path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add helper functions to normalize `_merged.csv`, extract價量資訊, and整理法人資料為寬表
- merge價量與法人資料成每日一行的清理檔案, 並輸出完整版與精簡版 CSV
- 印出清理結果摘要與缺值統計, 並在未找到資料時給予友善提醒

## Testing
- python -m compileall for_twstock/finmind_fetcher.py

------
https://chatgpt.com/codex/tasks/task_e_68cd13f4cf3083249445879a66ce3d19