### PR TITLE
Add multi-faceted stock analysis CLI module

### DIFF
--- a/analysis/__init__.py
+++ b/analysis/__init__.py
@@ -1,0 +1,39 @@
+"""分析模組封裝。"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+__all__ = [
+    "get_logger",
+]
+
+
+def get_logger(name: str) -> logging.Logger:
+    """以統一格式建立日誌記錄器。
+
+    參數
+    ----
+    name:
+        模組名稱。
+
+    返回
+    ----
+    logging.Logger
+        已設定好層級與輸出格式的記錄器。
+    """
+
+    logger = logging.getLogger(name)
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(
+            "%(asctime)s | %(levelname)s | %(name)s | %(message)s"
+        )
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+    return logger
+
+
+PACKAGE_ROOT = Path(__file__).resolve().parent

--- a/analysis/__main__.py
+++ b/analysis/__main__.py
@@ -1,0 +1,9 @@
+"""允許透過 `python -m analysis` 執行。"""
+
+from __future__ import annotations
+
+from .cli import main
+
+
+if __name__ == "__main__":  # pragma: no cover - 直接透過 CLI 執行
+    main()

--- a/analysis/capital.py
+++ b/analysis/capital.py
@@ -1,0 +1,92 @@
+"""計算資金與盤勢熱度指標。"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from . import get_logger
+from .utils import clip_score, percentile_rank
+
+LOGGER = get_logger(__name__)
+ROLLING_WINDOW = 5
+
+
+def _prepare(df: pd.DataFrame) -> pd.DataFrame:
+    df = df.copy()
+    numeric_cols = [
+        "turnover",
+        "volume",
+        "TaiwanStockPrice_transactions",
+    ]
+    for col in numeric_cols:
+        df[col] = pd.to_numeric(df[col], errors="coerce").fillna(0)
+    return df
+
+
+def calculate_capital_metrics(df: pd.DataFrame) -> pd.DataFrame:
+    """計算資金熱度相關欄位。"""
+
+    df = _prepare(df)
+
+    df["turnover_rank_pct"] = df.groupby("date")[["turnover"]].transform(percentile_rank)
+
+    df["turnover_ma5"] = df.groupby("stock_id")[["turnover"]].transform(
+        lambda s: s.rolling(window=ROLLING_WINDOW, min_periods=1).mean()
+    )
+    df["volume_ma5"] = df.groupby("stock_id")[["volume"]].transform(
+        lambda s: s.rolling(window=ROLLING_WINDOW, min_periods=1).mean()
+    )
+    df["transactions_ma5"] = df.groupby("stock_id")[["TaiwanStockPrice_transactions"]].transform(
+        lambda s: s.rolling(window=ROLLING_WINDOW, min_periods=1).mean()
+    )
+
+    df["turnover_change_5d"] = (df["turnover"] - df["turnover_ma5"]) / df["turnover_ma5"].replace(0, np.nan)
+    df["volume_change_5d"] = (df["volume"] - df["volume_ma5"]) / df["volume_ma5"].replace(0, np.nan)
+    df["transactions_change_5d"] = (
+        (df["TaiwanStockPrice_transactions"] - df["transactions_ma5"]) / df["transactions_ma5"].replace(0, np.nan)
+    )
+
+    df[["turnover_change_5d", "volume_change_5d", "transactions_change_5d"]] = df[
+        ["turnover_change_5d", "volume_change_5d", "transactions_change_5d"]
+    ].fillna(0)
+
+    df["capital_score"] = _score_capital(df)
+    return df
+
+
+def _score_capital(df: pd.DataFrame) -> pd.Series:
+    score = pd.Series(1.5, index=df.index, dtype=float)
+
+    score += np.where(df["turnover_rank_pct"] >= 0.7, 0.8, 0.0)
+    score += np.where(df["turnover_rank_pct"] <= 0.3, -0.8, 0.0)
+
+    score += np.where(df["turnover_change_5d"] >= 0.2, 0.6, 0.0)
+    score += np.where(df["turnover_change_5d"] <= -0.2, -0.6, 0.0)
+
+    score += np.where(df["volume_change_5d"] >= 0.2, 0.5, 0.0)
+    score += np.where(df["volume_change_5d"] <= -0.2, -0.5, 0.0)
+
+    score += np.where(df["transactions_change_5d"] >= 0.15, 0.3, 0.0)
+    score += np.where(df["transactions_change_5d"] <= -0.15, -0.3, 0.0)
+
+    score += np.where(df["turnover_rank_pct"] >= 0.9, 0.2, 0.0)
+    score += np.where(df["turnover_rank_pct"] <= 0.1, -0.2, 0.0)
+
+    return score.apply(lambda v: clip_score(v, 0.0, 3.0))
+
+
+if __name__ == "__main__":  # pragma: no cover - 自測
+    dates = pd.date_range("2024-01-01", periods=10, freq="B")
+    df = pd.DataFrame(
+        {
+            "date": dates.tolist() * 2,
+            "stock_id": ["2330"] * 10 + ["2317"] * 10,
+            "turnover": np.random.randint(1_000_000, 5_000_000, size=20),
+            "volume": np.random.randint(1_000, 5_000, size=20),
+            "TaiwanStockPrice_transactions": np.random.randint(100, 500, size=20),
+        }
+    )
+    enriched = calculate_capital_metrics(df)
+    assert "capital_score" in enriched.columns
+    print("capital 自測完成")

--- a/analysis/chips.py
+++ b/analysis/chips.py
@@ -1,0 +1,153 @@
+"""計算三大法人籌碼相關指標。"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+
+from . import get_logger
+from .utils import clip_score, last_turning_point
+
+LOGGER = get_logger(__name__)
+ROLLING_WINDOWS = (5, 10, 20)
+
+
+@dataclass
+class ChipSummary:
+    """封裝籌碼面摘要。"""
+
+    score: float
+    consecutive_buy: int
+    consecutive_sell: int
+    turning_point: str | None
+    note: str
+
+
+def _rolling_sum(series: pd.Series, window: int) -> pd.Series:
+    return series.rolling(window=window, min_periods=1).sum()
+
+
+def _consecutive_positive(series: pd.Series) -> pd.Series:
+    mask = series > 0
+    groups = (mask != mask.shift(fill_value=False)).cumsum()
+    streak = mask.groupby(groups).cumsum()
+    return streak.where(mask, 0)
+
+
+def _consecutive_negative(series: pd.Series) -> pd.Series:
+    mask = series < 0
+    groups = (mask != mask.shift(fill_value=False)).cumsum()
+    streak = mask.groupby(groups).cumsum()
+    return streak.where(mask, 0)
+
+
+def _score_chip(df: pd.DataFrame) -> pd.Series:
+    score = pd.Series(2.5, index=df.index, dtype=float)
+    for window in ROLLING_WINDOWS:
+        total = df[f"net_all_{window}"]
+        score += np.where(total > 0, 0.8, 0.0)
+        score += np.where(total < 0, -0.8, 0.0)
+
+    score += np.where(df["net_all_consecutive_buy"] >= 3, 0.8, 0.0)
+    score += np.where(df["net_all_consecutive_sell"] >= 3, -0.8, 0.0)
+
+    score += np.where(
+        (df["foreign_consecutive_buy"] >= 3) | (df["it_consecutive_buy"] >= 3),
+        0.6,
+        0.0,
+    )
+    score += np.where(
+        (df["foreign_consecutive_sell"] >= 3) | (df["it_consecutive_sell"] >= 3),
+        -0.6,
+        0.0,
+    )
+    return score.apply(lambda v: clip_score(v, 0.0, 5.0))
+
+
+def calculate_chip_metrics(stock_df: pd.DataFrame) -> pd.DataFrame:
+    """為單一股票新增籌碼相關欄位。"""
+
+    df = stock_df.copy()
+
+    foreign = df["inst_foreign"].fillna(0)
+    it = df["inst_investment_trust"].fillna(0)
+    dealer_self = df["inst_dealer_self"].fillna(0)
+    dealer_hedge = df["inst_dealer_hedging"].fillna(0)
+
+    df["net_dealer_total"] = dealer_self + dealer_hedge
+    df["net_all"] = foreign + it + df["net_dealer_total"]
+
+    for window in ROLLING_WINDOWS:
+        df[f"net_foreign_{window}"] = _rolling_sum(foreign, window)
+        df[f"net_it_{window}"] = _rolling_sum(it, window)
+        df[f"net_dealer_total_{window}"] = _rolling_sum(df["net_dealer_total"], window)
+        df[f"net_all_{window}"] = _rolling_sum(df["net_all"], window)
+
+    df["foreign_consecutive_buy"] = _consecutive_positive(foreign)
+    df["it_consecutive_buy"] = _consecutive_positive(it)
+    df["dealer_consecutive_buy"] = _consecutive_positive(df["net_dealer_total"])
+    df["net_all_consecutive_buy"] = _consecutive_positive(df["net_all"])
+
+    df["foreign_consecutive_sell"] = _consecutive_negative(foreign)
+    df["it_consecutive_sell"] = _consecutive_negative(it)
+    df["dealer_consecutive_sell"] = _consecutive_negative(df["net_dealer_total"])
+    df["net_all_consecutive_sell"] = _consecutive_negative(df["net_all"])
+
+    df["chip_score"] = _score_chip(df)
+
+    turn_point = last_turning_point(df.set_index("date")["net_all"])
+    if turn_point is not None:
+        LOGGER.debug("股票 %s 最近轉折日: %s", df["stock_id"].iloc[0], turn_point)
+
+    return df
+
+
+def summarize_chip(df: pd.DataFrame) -> ChipSummary:
+    """根據最新資料形成籌碼摘要。"""
+
+    latest = df.iloc[-1]
+    turning_point = last_turning_point(df.set_index("date")["net_all"])
+    turning_str = turning_point.strftime("%Y-%m-%d") if turning_point else None
+
+    consecutive_buy = int(latest["net_all_consecutive_buy"])
+    consecutive_sell = int(latest["net_all_consecutive_sell"])
+
+    notes: list[str] = []
+    if latest["foreign_consecutive_buy"] >= 3:
+        notes.append(f"外資連買 {int(latest['foreign_consecutive_buy'])} 日")
+    if latest["it_consecutive_buy"] >= 3:
+        notes.append(f"投信連買 {int(latest['it_consecutive_buy'])} 日")
+    if latest["foreign_consecutive_sell"] >= 3:
+        notes.append(f"外資連賣 {int(latest['foreign_consecutive_sell'])} 日")
+    if latest["it_consecutive_sell"] >= 3:
+        notes.append(f"投信連賣 {int(latest['it_consecutive_sell'])} 日")
+
+    note = "、".join(notes) if notes else "法人動向無明顯連續趨勢"
+
+    return ChipSummary(
+        score=float(latest["chip_score"]),
+        consecutive_buy=consecutive_buy,
+        consecutive_sell=consecutive_sell,
+        turning_point=turning_str,
+        note=note,
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover - 自測
+    dates = pd.date_range("2024-01-01", periods=30, freq="B")
+    sample = pd.DataFrame(
+        {
+            "date": dates,
+            "stock_id": "2330",
+            "inst_foreign": np.random.randint(-1000, 1000, size=len(dates)),
+            "inst_investment_trust": np.random.randint(-500, 500, size=len(dates)),
+            "inst_dealer_self": np.random.randint(-200, 200, size=len(dates)),
+            "inst_dealer_hedging": np.random.randint(-200, 200, size=len(dates)),
+        }
+    )
+    enriched = calculate_chip_metrics(sample)
+    summary = summarize_chip(enriched)
+    assert summary.score >= 0
+    print("chips 自測完成", summary)

--- a/analysis/cli.py
+++ b/analysis/cli.py
@@ -1,0 +1,227 @@
+"""指令列介面，串聯整體分析流程。"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List
+
+import pandas as pd
+
+from . import get_logger
+from .capital import calculate_capital_metrics
+from .chips import ChipSummary, calculate_chip_metrics, summarize_chip
+from .data_loader import load_wide_csv
+from .fundamentals import FundamentalAnalyzer, FundamentalSummary
+from .indicators import calculate_indicators
+from .recommender import RecommendationResult, make_recommendation
+from .report import StockReport, generate_reports
+from .utils import ensure_directory, format_date
+
+LOGGER = get_logger(__name__)
+
+
+@dataclass
+class StockAnalysis:
+    """封裝單一股票分析結果。"""
+
+    stock_id: str
+    data: pd.DataFrame
+    latest: pd.Series
+    chip_summary: ChipSummary
+    fund_summary: "FundamentalSummary"
+    recommendation: RecommendationResult
+
+
+def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    """解析 CLI 參數。"""
+
+    parser = argparse.ArgumentParser(description="台股四大面向分析工具")
+    parser.add_argument("--input", required=True, help="_clean_daily_wide.csv 路徑")
+    parser.add_argument("--outdir", default="outputs", help="輸出資料夾")
+    parser.add_argument("--since", help="僅分析此日期（含）之後資料")
+    parser.add_argument("--stocks", help="限定分析之股票代號，逗號分隔")
+    parser.add_argument("--with-charts", action="store_true", help="輸出圖表 PNG")
+    parser.add_argument("--html-report", action="store_true", help="輸出 HTML 彙總")
+    parser.add_argument("--finmind-token", help="FinMind API token")
+    parser.add_argument(
+        "--fundamentals-dir",
+        help="基本面 CSV 所在資料夾，例如 month_revenue.csv",
+    )
+    return parser.parse_args(argv)
+
+
+def _filter_data(df: pd.DataFrame, since: str | None, stocks: List[str] | None) -> pd.DataFrame:
+    filtered = df
+    if since:
+        try:
+            since_ts = pd.Timestamp(since).tz_localize("Asia/Taipei")
+        except (ValueError, TypeError) as exc:
+            raise ValueError(f"--since 參數格式錯誤: {since}") from exc
+        filtered = filtered[filtered["date"] >= since_ts]
+    if stocks:
+        stocks = [s.strip().zfill(4) for s in stocks]
+        filtered = filtered[filtered["stock_id"].isin(stocks)]
+    return filtered
+
+
+def _prepare_fundamental_analyzer(args: argparse.Namespace) -> FundamentalAnalyzer:
+    return FundamentalAnalyzer(
+        fundamentals_dir=args.fundamentals_dir,
+        finmind_token=args.finmind_token or None,
+    )
+
+
+def run_analysis(args: argparse.Namespace) -> list[StockAnalysis]:
+    df = load_wide_csv(args.input)
+
+    stocks_list = args.stocks.split(",") if args.stocks else None
+    df = _filter_data(df, args.since, stocks_list)
+
+    if df.empty:
+        LOGGER.error("套用條件後無資料，請確認輸入範圍")
+        sys.exit(1)
+
+    df = calculate_capital_metrics(df)
+
+    analyzer = _prepare_fundamental_analyzer(args)
+    results: list[StockAnalysis] = []
+
+    warnings: list[str] = []
+
+    for stock_id, group in df.groupby("stock_id"):
+        group = group.sort_values("date").reset_index(drop=True)
+        if len(group) < 20:
+            warnings.append(f"股票 {stock_id} 資料不足 20 筆，部分指標為空值")
+        group = calculate_indicators(group)
+        group = calculate_chip_metrics(group)
+
+        latest = group.iloc[-1]
+        chip_summary = summarize_chip(group)
+        fund_summary = analyzer.analyze(stock_id)
+        if fund_summary.score == 0 and "不足" in fund_summary.note:
+            warnings.append(f"股票 {stock_id} 基本面資料不足")
+        recommendation = make_recommendation(latest, chip_summary, fund_summary)
+
+        results.append(
+            StockAnalysis(
+                stock_id=stock_id,
+                data=group,
+                latest=latest,
+                chip_summary=chip_summary,
+                fund_summary=fund_summary,
+                recommendation=recommendation,
+            )
+        )
+
+    results.sort(key=lambda item: item.recommendation.total_score, reverse=True)
+
+    outdir = ensure_directory(args.outdir)
+    analysis_date = format_date(df["date"].max())
+
+    summary_rows = [_build_summary_row(res) for res in results]
+    warnings = list(dict.fromkeys(warnings))
+    summary_df = pd.DataFrame(summary_rows)
+
+    generate_reports(
+        summary_df=summary_df,
+        stock_reports=[
+            StockReport(
+                stock_id=res.stock_id,
+                latest=res.latest,
+                chip_summary=res.chip_summary,
+                fund_summary=res.fund_summary,
+                recommendation=res.recommendation,
+                data=res.data,
+            )
+            for res in results
+        ],
+        outdir=Path(outdir),
+        analysis_date=analysis_date,
+        with_charts=args.with_charts,
+        html_report=args.html_report,
+        warnings=warnings,
+    )
+
+    _print_console_summary(args, df, results, warnings)
+
+    return results
+
+
+def _build_summary_row(result: StockAnalysis) -> dict[str, object]:
+    latest = result.latest
+    vol_ma20 = latest.get("VOL_MA20")
+    vol_ratio = float(latest.get("volume", 0)) / vol_ma20 if vol_ma20 else float("nan")
+    return {
+        "stock_id": result.stock_id,
+        "date_last": format_date(latest.get("date")),
+        "close": latest.get("close"),
+        "pct_5d": latest.get("pct_5d"),
+        "pct_10d": latest.get("pct_10d"),
+        "pct_20d": latest.get("pct_20d"),
+        "MA20": latest.get("MA20"),
+        "MA60": latest.get("MA60"),
+        "MA20_slope": latest.get("MA20_slope"),
+        "MA60_slope": latest.get("MA60_slope"),
+        "VOL_VOL_MA20_ratio": vol_ratio,
+        "turnover_rank_pct": latest.get("turnover_rank_pct"),
+        "turnover_change_5d": latest.get("turnover_change_5d"),
+        "net_foreign_5": latest.get("net_foreign_5"),
+        "net_it_5": latest.get("net_it_5"),
+        "net_dealer_total_5": latest.get("net_dealer_total_5"),
+        "net_all_5": latest.get("net_all_5"),
+        "tech_score": latest.get("tech_score"),
+        "chip_score": latest.get("chip_score"),
+        "capital_score": latest.get("capital_score"),
+        "fund_score": result.fund_summary.score,
+        "total_score": result.recommendation.total_score,
+        "trend_class": result.recommendation.trend_class,
+        "chip_trend_note": result.recommendation.chip_trend_note,
+        "rationale": result.recommendation.rationale,
+        "recommendation": result.recommendation.recommendation,
+        "risk_flags": result.recommendation.risk_flags,
+    }
+
+
+def _print_console_summary(
+    args: argparse.Namespace,
+    df: pd.DataFrame,
+    results: list[StockAnalysis],
+    warnings: list[str],
+) -> None:
+    first_date = format_date(df["date"].min())
+    last_date = format_date(df["date"].max())
+    print(f"資料範圍：{first_date} ~ {last_date}")
+    print(f"股票數量：{len(results)}")
+    print(f"輸出目錄：{Path(args.outdir).resolve()}")
+
+    print("\n總分前 5 名：")
+    for item in results[:5]:
+        print(
+            f"  {item.stock_id} - {item.recommendation.total_score:.2f} 分 - {item.recommendation.recommendation}"
+        )
+
+    print("\n總分後 5 名：")
+    for item in results[-5:]:
+        print(
+            f"  {item.stock_id} - {item.recommendation.total_score:.2f} 分 - {item.recommendation.recommendation}"
+        )
+
+    if warnings:
+        print("\n警告：")
+        for message in warnings:
+            print(f"- {message}")
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    args = parse_args(argv)
+    run_analysis(args)
+
+
+if __name__ == "__main__":  # pragma: no cover - 自測
+    if len(sys.argv) > 1:
+        main()
+    else:
+        print("請使用 --input 指定資料檔案")

--- a/analysis/data_loader.py
+++ b/analysis/data_loader.py
@@ -1,0 +1,126 @@
+"""資料載入與清理流程。"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+import pandas as pd
+
+from . import get_logger
+from .utils import TAIPEI_TZ, to_taipei_datetime
+
+LOGGER = get_logger(__name__)
+
+REQUIRED_COLUMNS: tuple[str, ...] = (
+    "date",
+    "stock_id",
+    "volume",
+    "turnover",
+    "open",
+    "high",
+    "low",
+    "close",
+    "TaiwanStockPrice_spread",
+    "TaiwanStockPrice_transactions",
+    "inst_foreign",
+    "inst_investment_trust",
+    "inst_dealer_self",
+    "inst_dealer_hedging",
+)
+
+NUMERIC_COLUMNS: tuple[str, ...] = (
+    "volume",
+    "turnover",
+    "open",
+    "high",
+    "low",
+    "close",
+    "TaiwanStockPrice_spread",
+    "TaiwanStockPrice_transactions",
+    "inst_foreign",
+    "inst_investment_trust",
+    "inst_dealer_self",
+    "inst_dealer_hedging",
+)
+
+
+class MissingColumnsError(RuntimeError):
+    """缺欄位時拋出的例外。"""
+
+
+def _validate_columns(columns: Iterable[str]) -> list[str]:
+    missing = [col for col in REQUIRED_COLUMNS if col not in columns]
+    if missing:
+        raise MissingColumnsError(f"檔案缺少必要欄位: {missing}")
+    return list(columns)
+
+
+def _coerce_numeric(df: pd.DataFrame) -> pd.DataFrame:
+    for column in NUMERIC_COLUMNS:
+        df[column] = pd.to_numeric(df[column], errors="coerce")
+    return df
+
+
+def _clean_rows(df: pd.DataFrame) -> pd.DataFrame:
+    """移除重複列與明顯異常值。"""
+
+    before = len(df)
+    df = df.drop_duplicates(subset=["date", "stock_id"], keep="last")
+    if len(df) != before:
+        LOGGER.info("移除 %s 筆重複資料", before - len(df))
+
+    # 移除價格或量為負值的資料
+    mask_invalid = (
+        (df["volume"] < 0)
+        | (df["turnover"] < 0)
+        | (df["open"] <= 0)
+        | (df["high"] <= 0)
+        | (df["low"] <= 0)
+        | (df["close"] <= 0)
+        | (df["high"] < df["low"])
+    )
+    invalid_count = int(mask_invalid.sum())
+    if invalid_count > 0:
+        LOGGER.warning("偵測到 %s 筆異常資料，已移除", invalid_count)
+        df = df.loc[~mask_invalid]
+    return df
+
+
+def load_wide_csv(path: str | Path) -> pd.DataFrame:
+    """載入清理後的寬表資料。
+
+    返回的資料依 `stock_id`, `date` 排序，日期欄位為台北時區。
+    """
+
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(f"找不到資料檔案: {path}")
+
+    LOGGER.info("讀取資料檔案: %s", path)
+    df = pd.read_csv(path)
+
+    _validate_columns(df.columns)
+    df = _coerce_numeric(df)
+
+    df["date"] = to_taipei_datetime(df["date"])
+    df["stock_id"] = df["stock_id"].astype(str).str.zfill(4)
+
+    df = _clean_rows(df)
+
+    df = df.sort_values(["stock_id", "date"]).reset_index(drop=True)
+
+    LOGGER.info("資料列數: %s，股票數量: %s", len(df), df["stock_id"].nunique())
+    return df
+
+
+if __name__ == "__main__":  # pragma: no cover - 簡單自測
+    try:
+        sample_path = Path("_clean_daily_wide.csv")
+        if sample_path.exists():
+            sample_df = load_wide_csv(sample_path)
+            print(sample_df.head())
+        else:
+            print("找不到 _clean_daily_wide.csv，僅確認模組可引用")
+    except Exception as exc:  # noqa: BLE001 - 自測需攔截所有例外
+        print(f"自測失敗: {exc}")

--- a/analysis/fundamentals.py
+++ b/analysis/fundamentals.py
@@ -1,0 +1,243 @@
+"""取得並評估基本面資料。"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+from urllib.error import URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+import pandas as pd
+
+from . import get_logger
+from .utils import clip_score
+
+LOGGER = get_logger(__name__)
+FINMIND_API = "https://api.finmindtrade.com/api/v4/data"
+
+
+@dataclass
+class FundamentalSummary:
+    """封裝基本面分析結果。"""
+
+    score: float
+    note: str
+    revenue_yoy_avg: float | None = None
+    revenue_mom_avg: float | None = None
+    eps_recent: float | None = None
+
+
+class FundamentalAnalyzer:
+    """基本面資料彙整器。"""
+
+    def __init__(
+        self,
+        fundamentals_dir: str | Path | None = None,
+        finmind_token: str | None = None,
+    ) -> None:
+        self.fundamentals_dir = Path(fundamentals_dir) if fundamentals_dir else None
+        self.finmind_token = finmind_token or ""
+        self._revenue_df: Optional[pd.DataFrame] = None
+        self._income_df: Optional[pd.DataFrame] = None
+        if self.fundamentals_dir and not self.fundamentals_dir.exists():
+            LOGGER.warning("指定的基本面目錄不存在：%s", self.fundamentals_dir)
+
+    def analyze(self, stock_id: str) -> FundamentalSummary:
+        """針對單一股票計算基本面評分。"""
+
+        revenue_df = self._get_revenue_data(stock_id)
+        income_df = self._get_income_data(stock_id)
+
+        if revenue_df is None and income_df is None:
+            return FundamentalSummary(score=0.0, note="基本面資料不足")
+
+        yoy_avg, mom_avg = self._evaluate_revenue(revenue_df) if revenue_df is not None else (None, None)
+        eps_recent = self._evaluate_income(income_df) if income_df is not None else None
+
+        score = 1.5
+        note_parts: list[str] = []
+
+        if yoy_avg is not None:
+            if yoy_avg >= 0.2:
+                score += 1.5
+                note_parts.append("月營收年增率長期維持兩成以上")
+            elif yoy_avg >= 0.05:
+                score += 1.0
+                note_parts.append("月營收年增率保持成長")
+            elif yoy_avg < 0:
+                score -= 1.0
+                note_parts.append("月營收年增率走弱")
+        else:
+            note_parts.append("缺少足夠的年增率資料")
+
+        if mom_avg is not None:
+            if mom_avg >= 0.05:
+                score += 0.5
+                note_parts.append("近期月營收月增率轉強")
+            elif mom_avg <= -0.05:
+                score -= 0.5
+                note_parts.append("近期月營收月增率轉弱")
+        else:
+            note_parts.append("月增率資料不足")
+
+        if eps_recent is not None:
+            if eps_recent >= 2:
+                score += 1.0
+                note_parts.append("最近年度 EPS 顯著且穩健")
+            elif eps_recent > 0:
+                score += 0.5
+                note_parts.append("最近年度維持正獲利")
+            else:
+                score -= 1.0
+                note_parts.append("近期出現虧損")
+        else:
+            note_parts.append("未取得 EPS 或淨利資料")
+
+        score = clip_score(score, 0.0, 5.0)
+        note = "；".join(note_parts)
+
+        return FundamentalSummary(
+            score=score,
+            note=note,
+            revenue_yoy_avg=yoy_avg,
+            revenue_mom_avg=mom_avg,
+            eps_recent=eps_recent,
+        )
+
+    # -- 資料載入 ------------------------------------------------------------
+
+    def _get_revenue_data(self, stock_id: str) -> Optional[pd.DataFrame]:
+        if self._revenue_df is None:
+            self._revenue_df = self._load_local_csv("month_revenue")
+        df = self._revenue_df
+        if df is not None and not df.empty:
+            subset = df[df["stock_id"].astype(str) == stock_id].copy()
+            if subset.empty:
+                return None
+            subset["date"] = pd.to_datetime(subset["date"], errors="coerce")
+            subset = subset.dropna(subset=["date"]).sort_values("date")
+            return subset
+
+        if not self.finmind_token:
+            return None
+
+        try:
+            df = self._fetch_finmind("TaiwanStockMonthRevenue", stock_id)
+        except URLError as exc:  # pragma: no cover - 網路存取非測試重點
+            LOGGER.error("取得 FinMind 月營收資料失敗：%s", exc)
+            return None
+        if df is None or df.empty:
+            return None
+        df.rename(columns={"revenue": "value"}, inplace=True)
+        df = df.rename(columns={"value": "revenue"})
+        df["date"] = pd.to_datetime(df["date"], errors="coerce")
+        df = df.dropna(subset=["date"]).sort_values("date")
+        return df
+
+    def _get_income_data(self, stock_id: str) -> Optional[pd.DataFrame]:
+        if self._income_df is None:
+            self._income_df = self._load_local_csv("income_statement")
+        df = self._income_df
+        if df is not None and not df.empty:
+            subset = df[df["stock_id"].astype(str) == stock_id].copy()
+            if subset.empty:
+                return None
+            subset["date"] = pd.to_datetime(subset["date"], errors="coerce")
+            subset = subset.dropna(subset=["date"]).sort_values("date")
+            return subset
+
+        if not self.finmind_token:
+            return None
+        try:
+            df = self._fetch_finmind("TaiwanStockFinancialStatements", stock_id)
+        except URLError as exc:  # pragma: no cover - 網路存取非測試重點
+            LOGGER.error("取得 FinMind 財報資料失敗：%s", exc)
+            return None
+        if df is None or df.empty:
+            return None
+        df["date"] = pd.to_datetime(df["date"], errors="coerce")
+        df = df.dropna(subset=["date"]).sort_values("date")
+        return df
+
+    def _load_local_csv(self, keyword: str) -> Optional[pd.DataFrame]:
+        if not self.fundamentals_dir:
+            return None
+        candidates = sorted(self.fundamentals_dir.glob(f"{keyword}*.csv"))
+        if not candidates:
+            return None
+        path = candidates[0]
+        LOGGER.info("載入基本面檔案：%s", path)
+        df = pd.read_csv(path)
+        return df
+
+    def _fetch_finmind(self, dataset: str, stock_id: str) -> Optional[pd.DataFrame]:
+        params = {
+            "dataset": dataset,
+            "data_id": stock_id,
+            "token": self.finmind_token,
+        }
+        query = urlencode(params)
+        request = Request(f"{FINMIND_API}?{query}")
+        with urlopen(request, timeout=30) as response:  # noqa: S310 - 外部 API 存取
+            payload = json.loads(response.read().decode("utf-8"))
+        if payload.get("status") != 200:
+            LOGGER.error("FinMind API 回應錯誤：%s", payload.get("msg"))
+            return None
+        data = payload.get("data", [])
+        return pd.DataFrame(data)
+
+    # -- 評估邏輯 ------------------------------------------------------------
+
+    def _evaluate_revenue(self, df: pd.DataFrame) -> tuple[float | None, float | None]:
+        if df is None or df.empty:
+            return None, None
+        if "revenue" not in df.columns:
+            LOGGER.warning("月營收檔缺少 revenue 欄位，無法計算年增率")
+            return None, None
+        df = df.sort_values("date")
+        df["revenue"] = pd.to_numeric(df["revenue"], errors="coerce")
+        df = df.dropna(subset=["revenue"])
+        if len(df) < 12:
+            LOGGER.warning("月營收資料不足 12 個月")
+            return None, None
+
+        if "yoy" in df.columns:
+            df["yoy"] = pd.to_numeric(df["yoy"], errors="coerce") / 100
+        else:
+            df["yoy"] = df["revenue"].pct_change(periods=12)
+
+        if "mom" in df.columns:
+            df["mom"] = pd.to_numeric(df["mom"], errors="coerce") / 100
+        else:
+            df["mom"] = df["revenue"].pct_change(periods=1)
+
+        recent = df.iloc[-12:]
+        yoy_avg = float(recent["yoy"].mean()) if not recent["yoy"].isna().all() else None
+        mom_recent = df.iloc[-6:]
+        mom_avg = float(mom_recent["mom"].mean()) if not mom_recent["mom"].isna().all() else None
+        return yoy_avg, mom_avg
+
+    def _evaluate_income(self, df: pd.DataFrame) -> float | None:
+        if df is None or df.empty:
+            return None
+        df = df.sort_values("date")
+        eps_columns = [col for col in df.columns if col.lower() in {"eps", "eps_after_tax"}]
+        if eps_columns:
+            df[eps_columns[0]] = pd.to_numeric(df[eps_columns[0]], errors="coerce")
+            return float(df[eps_columns[0]].tail(4).mean())
+
+        net_income_columns = [col for col in df.columns if "net" in col.lower() and "income" in col.lower()]
+        if net_income_columns:
+            df[net_income_columns[0]] = pd.to_numeric(df[net_income_columns[0]], errors="coerce")
+            return float(df[net_income_columns[0]].tail(4).mean())
+        LOGGER.warning("財報檔案缺少 EPS 或淨利欄位")
+        return None
+
+
+if __name__ == "__main__":  # pragma: no cover - 自測
+    analyzer = FundamentalAnalyzer()
+    summary = analyzer.analyze("2330")
+    print("fundamentals 自測完成", summary)

--- a/analysis/indicators.py
+++ b/analysis/indicators.py
@@ -1,0 +1,148 @@
+"""計算技術分析指標。"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from . import get_logger
+from .utils import clip_score, percent_change, rolling_slope
+
+LOGGER = get_logger(__name__)
+
+MA_WINDOWS = (5, 10, 20, 60, 120)
+EMA_SHORT = 12
+EMA_LONG = 26
+EMA_SIGNAL = 9
+RSI_PERIODS = (6, 14)
+BOLL_WINDOW = 20
+BOLL_STD = 2
+SLOPE_WINDOW = 5
+VOL_WINDOWS = (5, 20)
+
+
+def _moving_average(series: pd.Series, window: int) -> pd.Series:
+    return series.rolling(window=window, min_periods=window).mean()
+
+
+def _ema(series: pd.Series, span: int) -> pd.Series:
+    return series.ewm(span=span, adjust=False, min_periods=span).mean()
+
+
+def _calc_rsi(series: pd.Series, window: int) -> pd.Series:
+    delta = series.diff()
+    gain = delta.clip(lower=0)
+    loss = -delta.clip(upper=0)
+    avg_gain = gain.rolling(window=window, min_periods=window).mean()
+    avg_loss = loss.rolling(window=window, min_periods=window).mean()
+    rs = avg_gain / avg_loss.replace(0, np.nan)
+    rsi = 100 - (100 / (1 + rs))
+    return rsi
+
+
+def _bollinger(close: pd.Series) -> dict[str, pd.Series]:
+    ma = _moving_average(close, BOLL_WINDOW)
+    std = close.rolling(window=BOLL_WINDOW, min_periods=BOLL_WINDOW).std()
+    return {
+        "BB_MA20": ma,
+        "BB_UP": ma + BOLL_STD * std,
+        "BB_DOWN": ma - BOLL_STD * std,
+    }
+
+
+def _volume_ma(volume: pd.Series, window: int) -> pd.Series:
+    return volume.rolling(window=window, min_periods=window).mean()
+
+
+def _score_technical(df: pd.DataFrame) -> pd.Series:
+    score = pd.Series(2.5, index=df.index, dtype=float)
+
+    ma20 = df["MA20"]
+    ma60 = df["MA60"]
+    close = df["close"]
+
+    score += np.where((close > ma20) & (ma20 > ma60), 1.0, 0.0)
+    score += np.where((close < ma20) & (ma20 < ma60), -1.0, 0.0)
+
+    ma20_prev = ma20.shift(1)
+    ma60_prev = ma60.shift(1)
+    golden = (ma20 > ma60) & (ma20_prev <= ma60_prev)
+    death = (ma20 < ma60) & (ma20_prev >= ma60_prev)
+    score += np.where(golden, 0.5, 0.0)
+    score += np.where(death, -0.5, 0.0)
+
+    ma5 = df["MA5"]
+    ma5_prev = ma5.shift(1)
+    ma20_prev2 = ma20.shift(1)
+    golden_short = (ma5 > ma20) & (ma5_prev <= ma20_prev2)
+    death_short = (ma5 < ma20) & (ma5_prev >= ma20_prev2)
+    score += np.where(golden_short, 0.3, 0.0)
+    score += np.where(death_short, -0.3, 0.0)
+
+    rsi14 = df["RSI14"]
+    score += np.where(rsi14 > 70, -0.7, 0.0)
+    score += np.where(rsi14 < 30, 0.4, 0.0)
+
+    boll_mid = df["BB_MA20"]
+    score += np.where((close >= boll_mid) & close.notna(), 0.3, 0.0)
+    score += np.where(close > df["BB_UP"] * 1.03, -0.4, 0.0)
+    score += np.where(close < df["BB_DOWN"] * 0.97, 0.2, 0.0)
+
+    volume_ratio = df["volume"] / df["VOL_MA20"]
+    score += np.where(volume_ratio >= 1.5, 0.5, 0.0)
+    score += np.where(volume_ratio <= 0.8, -0.3, 0.0)
+
+    return score.apply(lambda v: clip_score(v, 0.0, 5.0))
+
+
+def calculate_indicators(stock_df: pd.DataFrame) -> pd.DataFrame:
+    """為單一股票計算技術指標並返回新資料表。"""
+
+    df = stock_df.copy()
+
+    for window in MA_WINDOWS:
+        df[f"MA{window}"] = _moving_average(df["close"], window)
+
+    for window in RSI_PERIODS:
+        df[f"RSI{window}"] = _calc_rsi(df["close"], window)
+
+    for window in VOL_WINDOWS:
+        df[f"VOL_MA{window}"] = _volume_ma(df["volume"], window)
+
+    ema_short = _ema(df["close"], EMA_SHORT)
+    ema_long = _ema(df["close"], EMA_LONG)
+    df["EMA12"] = ema_short
+    df["EMA26"] = ema_long
+    df["DIF"] = ema_short - ema_long
+    df["DEA"] = _ema(df["DIF"], EMA_SIGNAL)
+    df["MACD"] = 2 * (df["DIF"] - df["DEA"])
+
+    boll = _bollinger(df["close"])
+    for key, value in boll.items():
+        df[key] = value
+
+    df["MA20_slope"] = rolling_slope(df["MA20"], SLOPE_WINDOW)
+    df["MA60_slope"] = rolling_slope(df["MA60"], SLOPE_WINDOW)
+
+    df["pct_5d"] = percent_change(df["close"], 5)
+    df["pct_10d"] = percent_change(df["close"], 10)
+    df["pct_20d"] = percent_change(df["close"], 20)
+
+    df["tech_score"] = _score_technical(df)
+
+    return df
+
+
+if __name__ == "__main__":  # pragma: no cover - 模組自測
+    dates = pd.date_range("2024-01-01", periods=200, freq="B")
+    close = pd.Series(np.linspace(100, 150, len(dates)))
+    volume = pd.Series(np.random.randint(1000, 5000, size=len(dates)))
+    sample = pd.DataFrame({
+        "date": dates,
+        "close": close,
+        "volume": volume,
+    })
+    enriched = calculate_indicators(sample)
+    assert "MA20" in enriched.columns
+    assert enriched["tech_score"].iloc[-1] >= 0
+    print("indicators 自測完成")

--- a/analysis/recommender.py
+++ b/analysis/recommender.py
@@ -1,0 +1,195 @@
+"""根據各面向分數給出投資建議。"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pandas as pd
+
+from . import get_logger
+from .chips import ChipSummary
+from .fundamentals import FundamentalSummary
+from .utils import clip_score
+
+LOGGER = get_logger(__name__)
+
+# -- 調整參數區 -------------------------------------------------------------
+TREND_VOLUME_THRESHOLD = 1.5
+TREND_WEAK_VOLUME_THRESHOLD = 0.8
+RSI_OVERBOUGHT = 80
+RSI_OVERSOLD = 30
+
+RECOMMENDATION_RULES: dict[str, float] = {
+    "BULLISH": 13.0,
+    "ACCUMULATE": 10.0,
+    "NEUTRAL": 7.0,
+}
+
+
+@dataclass
+class RecommendationResult:
+    """投資建議輸出資料。"""
+
+    total_score: float
+    recommendation: str
+    rationale: str
+    trend_class: str
+    chip_trend_note: str
+    risk_flags: str
+
+
+def aggregate_scores(row: pd.Series, fund_score: float) -> float:
+    total = float(row.get("tech_score", 0))
+    total += float(row.get("chip_score", 0))
+    total += float(row.get("capital_score", 0))
+    total += float(fund_score)
+    return clip_score(total, 0.0, 18.0)
+
+
+def classify_trend(row: pd.Series) -> str:
+    ma20 = row.get("MA20")
+    ma60 = row.get("MA60")
+    slope20 = row.get("MA20_slope")
+    slope60 = row.get("MA60_slope")
+    close = row.get("close")
+
+    if pd.notna(close) and pd.notna(ma20) and pd.notna(ma60):
+        if close > ma20 > ma60 and (slope20 or 0) > 0 and (slope60 or 0) >= 0:
+            return "Up"
+        if close < ma20 < ma60 and (slope20 or 0) < 0:
+            return "Down"
+    return "Sideways"
+
+
+def build_chip_note(chip_summary: ChipSummary) -> str:
+    note_parts = []
+    if chip_summary.consecutive_buy:
+        note_parts.append(f"近連買 {chip_summary.consecutive_buy} 日")
+    if chip_summary.consecutive_sell:
+        note_parts.append(f"近連賣 {chip_summary.consecutive_sell} 日")
+    if chip_summary.turning_point:
+        note_parts.append(f"轉折日 {chip_summary.turning_point}")
+    if chip_summary.note:
+        note_parts.append(chip_summary.note)
+    return "；".join(note_parts)
+
+
+def detect_risk_flags(row: pd.Series) -> list[str]:
+    flags: list[str] = []
+    rsi14 = row.get("RSI14")
+    if pd.notna(rsi14) and rsi14 >= RSI_OVERBOUGHT:
+        flags.append("RSI 高檔過熱")
+    if pd.notna(rsi14) and rsi14 <= RSI_OVERSOLD:
+        flags.append("RSI 接近超賣")
+    volume_ratio = row.get("VOL_MA20")
+    if pd.notna(volume_ratio) and volume_ratio != 0:
+        vol_ratio = float(row.get("volume", 0)) / float(volume_ratio)
+        if vol_ratio >= TREND_VOLUME_THRESHOLD * 2:
+            flags.append("爆量需留意籌碼消化")
+        if vol_ratio <= 0.5:
+            flags.append("量能急凍")
+    if pd.notna(row.get("MACD")) and pd.notna(row.get("DEA")):
+        macd = row.get("MACD")
+        dea = row.get("DEA")
+        if macd < 0 and dea > 0:
+            flags.append("MACD 轉弱")
+    return flags
+
+
+def build_rationale(row: pd.Series, chip_summary: ChipSummary, fund_summary: FundamentalSummary) -> str:
+    points: list[str] = []
+    close = row.get("close")
+    ma20 = row.get("MA20")
+    ma60 = row.get("MA60")
+    if pd.notna(close) and pd.notna(ma20) and pd.notna(ma60):
+        if close > ma20 > ma60:
+            points.append("均線多頭排列")
+        elif close < ma20 < ma60:
+            points.append("均線空頭排列")
+
+    if pd.notna(row.get("RSI14")):
+        rsi = row.get("RSI14")
+        if rsi < 30:
+            points.append("RSI 進入超賣區有反彈契機")
+        elif rsi > 70:
+            points.append("RSI 過熱需謹慎")
+
+    volume_ratio = None
+    if pd.notna(row.get("VOL_MA20")) and row.get("VOL_MA20"):
+        volume_ratio = float(row.get("volume", 0)) / float(row.get("VOL_MA20"))
+        if volume_ratio >= TREND_VOLUME_THRESHOLD:
+            points.append("量能放大支撐趨勢")
+        elif volume_ratio <= TREND_WEAK_VOLUME_THRESHOLD:
+            points.append("量能萎縮趨勢易震盪")
+
+    if row.get("net_all_10", 0) > 0:
+        points.append("近 10 日法人合計買超")
+    elif row.get("net_all_10", 0) < 0:
+        points.append("近 10 日法人合計賣超")
+
+    if fund_summary.score == 0:
+        points.append("基本面資料不足，建議另行查證")
+    else:
+        points.append(f"基本面評分 {fund_summary.score:.1f}，{fund_summary.note}")
+
+    chip_note = build_chip_note(chip_summary)
+    if chip_note:
+        points.append(chip_note)
+
+    return "；".join(points)
+
+
+def determine_recommendation(total_score: float) -> str:
+    if total_score >= RECOMMENDATION_RULES["BULLISH"]:
+        return "偏多/關注買進"
+    if total_score >= RECOMMENDATION_RULES["ACCUMULATE"]:
+        return "區間偏多/逢回布局"
+    if total_score >= RECOMMENDATION_RULES["NEUTRAL"]:
+        return "中性觀望/區間操作"
+    return "偏空/迴避"
+
+
+def make_recommendation(
+    row: pd.Series,
+    chip_summary: ChipSummary,
+    fund_summary: FundamentalSummary,
+) -> RecommendationResult:
+    """整合所有分數產出建議。"""
+
+    total_score = aggregate_scores(row, fund_summary.score)
+    trend = classify_trend(row)
+    rationale = build_rationale(row, chip_summary, fund_summary)
+    risk = detect_risk_flags(row)
+    recommendation = determine_recommendation(total_score)
+
+    return RecommendationResult(
+        total_score=total_score,
+        recommendation=recommendation,
+        rationale=rationale,
+        trend_class=trend,
+        chip_trend_note=build_chip_note(chip_summary),
+        risk_flags="、".join(risk) if risk else "",
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover - 自測
+    sample = pd.Series(
+        {
+            "close": 600,
+            "MA20": 580,
+            "MA60": 550,
+            "MA20_slope": 2,
+            "MA60_slope": 1,
+            "RSI14": 65,
+            "VOL_MA20": 1000,
+            "volume": 1500,
+            "tech_score": 4,
+            "chip_score": 3,
+            "capital_score": 2,
+            "net_all_10": 5000,
+        }
+    )
+    chip_summary = ChipSummary(3, 2, 0, None, "外資小幅買超")
+    fund_summary = FundamentalSummary(4, "月營收年增率穩定")
+    result = make_recommendation(sample, chip_summary, fund_summary)
+    print("recommender 自測完成", result)

--- a/analysis/report.py
+++ b/analysis/report.py
@@ -1,0 +1,350 @@
+"""產生分析報告與圖表。"""
+
+from __future__ import annotations
+
+import io
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+import matplotlib
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+from . import get_logger
+from .chips import ChipSummary
+from .fundamentals import FundamentalSummary
+from .recommender import RecommendationResult
+from .utils import ensure_directory, format_date
+
+matplotlib.use("Agg")
+LOGGER = get_logger(__name__)
+
+
+@dataclass
+class StockReport:
+    """個股報告所需資料。"""
+
+    stock_id: str
+    latest: pd.Series
+    chip_summary: ChipSummary
+    fund_summary: FundamentalSummary
+    recommendation: RecommendationResult
+    data: pd.DataFrame
+
+
+# -- 輔助 -------------------------------------------------------------------
+
+
+def _ascii_histogram(values: Iterable[float], bins: int = 10) -> str:
+    values = list(values)
+    if not values:
+        return "無資料"
+    counts, edges = np.histogram(values, bins=bins, range=(0, 18))
+    max_count = counts.max() or 1
+    lines = []
+    for idx, count in enumerate(counts):
+        bar = "#" * int(count / max_count * 40)
+        lines.append(f"{edges[idx]:4.1f}~{edges[idx+1]:4.1f}: {bar} ({count})")
+    return "\n".join(lines)
+
+
+def _save_figure(fig: plt.Figure, path: Path) -> None:
+    ensure_directory(path.parent)
+    fig.savefig(path, bbox_inches="tight", dpi=150)
+    plt.close(fig)
+
+
+def _df_to_markdown(df: pd.DataFrame) -> str:
+    if df.empty:
+        return "（無資料）"
+    headers = list(df.columns)
+    header_line = "| " + " | ".join(headers) + " |"
+    divider = "| " + " | ".join(["---"] * len(headers)) + " |"
+    lines = [header_line, divider]
+    for _, row in df.iterrows():
+        values = []
+        for col in headers:
+            value = row[col]
+            if isinstance(value, float):
+                values.append(f"{value:.2f}")
+            else:
+                values.append(str(value))
+        lines.append("| " + " | ".join(values) + " |")
+    return "\n".join(lines)
+
+
+# -- 圖表 -------------------------------------------------------------------
+
+
+def _plot_price(df: pd.DataFrame, stock_id: str) -> plt.Figure:
+    fig, axes = plt.subplots(4, 1, figsize=(10, 12), sharex=True)
+    price_ax, volume_ax, macd_ax, rsi_ax = axes
+
+    price_ax.plot(df["date"], df["close"], label="收盤價", color="#1f77b4")
+    for window in [5, 20, 60]:
+        ma_col = f"MA{window}"
+        if ma_col in df.columns:
+            price_ax.plot(df["date"], df[ma_col], label=f"MA{window}")
+    price_ax.set_ylabel("價格")
+    price_ax.set_title(f"{stock_id} 價格與均線")
+    price_ax.legend(loc="upper left")
+    price_ax.grid(True, linestyle="--", alpha=0.3)
+
+    volume_ax.bar(df["date"], df["volume"], color="#ff7f0e", label="成交量")
+    if "VOL_MA20" in df.columns:
+        volume_ax.plot(df["date"], df["VOL_MA20"], color="#2ca02c", label="20日均量")
+    volume_ax.set_ylabel("成交量")
+    volume_ax.legend(loc="upper left")
+
+    macd_ax.plot(df["date"], df.get("DIF"), label="DIF")
+    macd_ax.plot(df["date"], df.get("DEA"), label="DEA")
+    macd_ax.bar(
+        df["date"],
+        df.get("MACD"),
+        label="MACD",
+        color=["#d62728" if val >= 0 else "#2ca02c" for val in df.get("MACD", pd.Series(0, index=df.index))],
+        alpha=0.6,
+    )
+    macd_ax.set_ylabel("MACD")
+    macd_ax.legend(loc="upper left")
+
+    rsi_ax.plot(df["date"], df.get("RSI14"), label="RSI14", color="#9467bd")
+    rsi_ax.axhline(70, color="red", linestyle="--", alpha=0.5)
+    rsi_ax.axhline(30, color="green", linestyle="--", alpha=0.5)
+    rsi_ax.set_ylabel("RSI")
+    rsi_ax.set_xlabel("日期")
+    rsi_ax.legend(loc="upper left")
+
+    for ax in axes:
+        ax.tick_params(axis="x", rotation=15)
+
+    fig.tight_layout()
+    return fig
+
+
+def _plot_chip(df: pd.DataFrame, stock_id: str) -> plt.Figure:
+    fig, ax = plt.subplots(figsize=(10, 4))
+    ax.plot(df["date"], df.get("net_foreign_5"), label="外資 5 日累計")
+    ax.plot(df["date"], df.get("net_it_5"), label="投信 5 日累計")
+    ax.plot(df["date"], df.get("net_dealer_total_5"), label="自營商 5 日累計")
+    ax.plot(df["date"], df.get("net_all_5"), label="三大法人合計 5 日")
+    ax.axhline(0, color="black", linewidth=0.8)
+    ax.set_title(f"{stock_id} 籌碼累計")
+    ax.set_ylabel("單位：股數/張數")
+    ax.set_xlabel("日期")
+    ax.legend(loc="upper left")
+    ax.tick_params(axis="x", rotation=15)
+    fig.tight_layout()
+    return fig
+
+
+# -- 報告 -------------------------------------------------------------------
+
+
+def generate_reports(
+    summary_df: pd.DataFrame,
+    stock_reports: list[StockReport],
+    outdir: Path,
+    analysis_date: str,
+    with_charts: bool,
+    html_report: bool,
+    warnings: list[str] | None = None,
+) -> None:
+    """輸出彙總表、Markdown 及個股報告。"""
+
+    ensure_directory(outdir)
+    date_tag = analysis_date.replace("-", "")
+
+    csv_path = outdir / f"recent_trend_chip_reco_{date_tag}.csv"
+    summary_df.to_csv(csv_path, index=False)
+    LOGGER.info("已輸出 CSV：%s", csv_path)
+
+    summary_md_path = outdir / f"summary_{date_tag}.md"
+    _write_summary_markdown(summary_md_path, summary_df, stock_reports, warnings)
+
+    if html_report:
+        html_path = outdir / f"summary_{date_tag}.html"
+        _write_summary_html(html_path, summary_df)
+
+    report_dir = outdir / "reports"
+    chart_dir = outdir / "charts"
+
+    for report in stock_reports:
+        chart_paths: list[str] = []
+        if with_charts:
+            price_fig = _plot_price(report.data, report.stock_id)
+            price_path = chart_dir / f"{report.stock_id}_{date_tag}_price.png"
+            _save_figure(price_fig, price_path)
+            chip_fig = _plot_chip(report.data, report.stock_id)
+            chip_path = chart_dir / f"{report.stock_id}_{date_tag}_chip.png"
+            _save_figure(chip_fig, chip_path)
+            chart_paths = [price_path.name, chip_path.name]
+
+        _write_stock_markdown(report_dir, report, chart_paths, analysis_date)
+
+
+def _write_summary_markdown(
+    path: Path,
+    summary_df: pd.DataFrame,
+    stock_reports: list[StockReport],
+    warnings: list[str] | None,
+) -> None:
+    ensure_directory(path.parent)
+    top20 = summary_df.nlargest(20, "total_score")
+    bottom20 = summary_df.nsmallest(20, "total_score")
+
+    histogram = _ascii_histogram(summary_df["total_score"], bins=8)
+
+    buffer = io.StringIO()
+    max_date = pd.to_datetime(summary_df["date_last"]).max()
+    buffer.write(f"# 日度分析總結（{format_date(max_date)}）\n\n")
+    buffer.write("## 方法論說明\n")
+    buffer.write(
+        "- 技術面：觀察均線排列、RSI、布林通道與量價關係。\n"
+        "- 籌碼面：重視外資與投信連續性、三大法人合計趨勢。\n"
+        "- 資金面：比較成交金額、成交量與成交筆數的升溫程度。\n"
+        "- 基本面：以月營收 YoY/MoM 與 EPS 變化評估長期競爭力。\n\n"
+    )
+
+    if warnings:
+        buffer.write("## 警告與限制\n")
+        for warning in warnings:
+            buffer.write(f"- {warning}\n")
+        buffer.write("\n")
+
+    buffer.write("## 分數分佈概覽\n")
+    buffer.write("````text\n")
+    buffer.write(histogram + "\n")
+    buffer.write("````\n\n")
+
+    buffer.write("## 總分前 20 名\n")
+    buffer.write(_df_to_markdown(top20.reset_index(drop=True)) + "\n\n")
+
+    buffer.write("## 總分後 20 名\n")
+    buffer.write(_df_to_markdown(bottom20.reset_index(drop=True)) + "\n\n")
+
+    buffer.write("## 指標解讀備忘\n")
+    buffer.write(
+        "- MACD 正值代表短期動能較強，DIF 向上突破 DEA 為黃金交叉。\n"
+        "- RSI 30 以下視為超賣，70 以上可能過熱，需搭配趨勢判斷。\n"
+        "- 布林帶上軌突破若無量能支撐，常出現拉回。\n"
+        "- 量能放大（>20 日均量 1.5 倍）代表趨勢可信度提升。\n\n"
+    )
+
+    with path.open("w", encoding="utf-8") as fh:
+        fh.write(buffer.getvalue())
+    LOGGER.info("已輸出 Markdown 摘要：%s", path)
+
+
+def _write_summary_html(path: Path, summary_df: pd.DataFrame) -> None:
+    ensure_directory(path.parent)
+    table_html = summary_df.to_html(index=False)
+    content = f"""
+<!DOCTYPE html>
+<html lang="zh-Hant">
+<head>
+<meta charset="utf-8" />
+<title>日度分析彙總</title>
+<style>
+body {{ font-family: "Noto Sans TC", sans-serif; margin: 2rem; }}
+table {{ border-collapse: collapse; width: 100%; }}
+th, td {{ border: 1px solid #ccc; padding: 0.4rem; text-align: right; }}
+th {{ background-color: #f5f5f5; }}
+td:first-child, th:first-child {{ text-align: left; }}
+</style>
+</head>
+<body>
+<h1>近期走勢與籌碼建議</h1>
+{table_html}
+</body>
+</html>
+"""
+    path.write_text(content, encoding="utf-8")
+    LOGGER.info("已輸出 HTML 摘要：%s", path)
+
+
+def _write_stock_markdown(
+    report_dir: Path,
+    report: StockReport,
+    chart_paths: list[str],
+    analysis_date: str,
+) -> None:
+    ensure_directory(report_dir)
+    path = report_dir / f"{report.stock_id}_{analysis_date.replace('-', '')}.md"
+    latest = report.latest
+
+    buffer = io.StringIO()
+    buffer.write(f"# {report.stock_id} 個股分析（{analysis_date}）\n\n")
+    buffer.write("## 分數總覽\n")
+    buffer.write(
+        "| 面向 | 分數 |\n| --- | ---: |\n"
+        f"| 技術面 | {latest.get('tech_score', float('nan')):.2f} |\n"
+        f"| 籌碼面 | {latest.get('chip_score', float('nan')):.2f} |\n"
+        f"| 資金面 | {latest.get('capital_score', float('nan')):.2f} |\n"
+        f"| 基本面 | {report.fund_summary.score:.2f} |\n"
+        f"| 總分 | {report.recommendation.total_score:.2f} |\n\n"
+    )
+
+    buffer.write("## 投資建議摘要\n")
+    buffer.write(f"- 建議：{report.recommendation.recommendation}\n")
+    buffer.write(f"- 趨勢分類：{report.recommendation.trend_class}\n")
+    buffer.write(f"- 籌碼觀察：{report.recommendation.chip_trend_note}\n")
+    if report.recommendation.risk_flags:
+        buffer.write(f"- 風險提示：{report.recommendation.risk_flags}\n")
+    buffer.write(f"- 理由整理：{report.recommendation.rationale}\n\n")
+
+    buffer.write("## 技術面觀察\n")
+    buffer.write(
+        "- 均線與趨勢斜率：觀察 MA20 與 MA60 的方向，正斜率代表趨勢向上。\n"
+        "- MACD：DIF 與 DEA 正交叉代表多方動能，負交叉需留意回檔。\n"
+        "- RSI：70 以上過熱、30 以下過冷，搭配布林帶判斷反轉。\n\n"
+    )
+
+    buffer.write("## 籌碼面觀察\n")
+    buffer.write(
+        f"- 三大法人近 5 日合計：{latest.get('net_all_5', float('nan')):.0f}\n"
+        f"- 外資近 5 日：{latest.get('net_foreign_5', float('nan')):.0f}\n"
+        f"- 投信近 5 日：{latest.get('net_it_5', float('nan')):.0f}\n"
+        f"- 自營商近 5 日：{latest.get('net_dealer_total_5', float('nan')):.0f}\n"
+        f"- 籌碼摘要：{report.chip_summary.note}\n\n"
+    )
+
+    buffer.write("## 資金面觀察\n")
+    buffer.write(
+        f"- 成交金額分位數：{latest.get('turnover_rank_pct', float('nan')):.2f}\n"
+        f"- 成交金額變化（5 日）：{latest.get('turnover_change_5d', float('nan')):.2%}\n"
+        f"- 成交量變化（5 日）：{latest.get('volume_change_5d', float('nan')):.2%}\n"
+        f"- 成交筆數變化（5 日）：{latest.get('transactions_change_5d', float('nan')):.2%}\n\n"
+    )
+
+    buffer.write("## 基本面觀察\n")
+    buffer.write(f"- 評語：{report.fund_summary.note}\n")
+    if report.fund_summary.revenue_yoy_avg is not None:
+        buffer.write(f"- 近 12 個月月營收年增率平均：{report.fund_summary.revenue_yoy_avg:.2%}\n")
+    if report.fund_summary.revenue_mom_avg is not None:
+        buffer.write(f"- 近 6 個月月營收月增率平均：{report.fund_summary.revenue_mom_avg:.2%}\n")
+    if report.fund_summary.eps_recent is not None:
+        buffer.write(f"- 最近年度 EPS 平均：{report.fund_summary.eps_recent:.2f}\n")
+    buffer.write("\n")
+
+    if chart_paths:
+        buffer.write("## 圖表\n")
+        for chart in chart_paths:
+            buffer.write(f"![圖表](../charts/{chart})\n")
+        buffer.write("\n")
+
+    buffer.write("## 指標說明\n")
+    buffer.write(
+        "- MA：簡單移動平均，反映趨勢方向。\n"
+        "- EMA：指數平均，較重視近期價格。\n"
+        "- MACD：動能指標，柱狀體由 DIF 與 DEA 差值乘以 2。\n"
+        "- RSI：相對強弱指數，常用 14 日衡量超買超賣。\n"
+        "- 布林帶：以 20 日均線為中心 ±2 倍標準差。\n"
+        "- 量能：以 20 日均量為基礎衡量放量或縮量。\n"
+        "- 法人累計：統計外資、投信、自營商近 5/10/20 日動向。\n"
+    )
+
+    path.write_text(buffer.getvalue(), encoding="utf-8")
+    LOGGER.info("已輸出個股報告：%s", path)

--- a/analysis/utils.py
+++ b/analysis/utils.py
@@ -1,0 +1,153 @@
+"""提供分析模組共用工具函式。"""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, Optional
+
+import numpy as np
+import pandas as pd
+
+TAIPEI_TZ = "Asia/Taipei"
+
+
+def ensure_directory(path: Path | str) -> Path:
+    """確保輸出目錄存在並返回路徑物件。
+
+    參數
+    ----
+    path:
+        目標目錄路徑。
+
+    返回
+    ----
+    Path
+        已建立的目錄路徑。
+    """
+
+    directory = Path(path)
+    directory.mkdir(parents=True, exist_ok=True)
+    return directory
+
+
+def to_taipei_datetime(series: pd.Series) -> pd.Series:
+    """將日期序列轉換為台北時區的 `Timestamp`。
+
+    若原始值不含時區，會以 `Asia/Taipei` 進行本地化。
+    """
+
+    dt_series = pd.to_datetime(series, errors="coerce")
+    if getattr(dt_series.dt, "tz", None) is None:
+        return dt_series.dt.tz_localize(TAIPEI_TZ)
+    return dt_series.dt.tz_convert(TAIPEI_TZ)
+
+
+def format_date(date: pd.Timestamp | datetime | str) -> str:
+    """將日期物件格式化為 `YYYY-MM-DD` 字串。"""
+
+    if isinstance(date, str):
+        return date[:10]
+    if isinstance(date, pd.Timestamp):
+        if date.tzinfo is not None:
+            date = date.tz_convert(TAIPEI_TZ)
+        return date.strftime("%Y-%m-%d")
+    if isinstance(date, datetime):
+        return date.strftime("%Y-%m-%d")
+    raise TypeError(f"不支援的日期型別: {type(date)!r}")
+
+
+def clip_score(value: float, lower: float, upper: float) -> float:
+    """將分數限制於指定上下限範圍內。"""
+
+    if math.isnan(value):
+        return lower
+    return max(lower, min(upper, value))
+
+
+def safe_divide(numerator: float, denominator: float) -> float:
+    """執行安全除法，若分母為 0 則回傳 0。"""
+
+    if denominator == 0:
+        return 0.0
+    return numerator / denominator
+
+
+def rolling_slope(series: pd.Series, window: int) -> pd.Series:
+    """以最小平方法估計滾動斜率。
+
+    斜率代表單位日的變化量，採用簡化線性回歸。
+    """
+
+    if window <= 1:
+        raise ValueError("window 必須大於 1")
+
+    x = np.arange(window)
+    x_mean = x.mean()
+    x_var = ((x - x_mean) ** 2).sum()
+
+    def _slope(values: np.ndarray) -> float:
+        if np.isnan(values).all():
+            return np.nan
+        y = np.array(values, dtype=float)
+        y_mean = np.nanmean(y)
+        cov = np.nansum((x - x_mean) * (y - y_mean))
+        if x_var == 0:
+            return 0.0
+        return cov / x_var
+
+    return series.rolling(window=window, min_periods=window).apply(_slope, raw=True)
+
+
+def consecutive_days(values: Iterable[float], positive: bool = True) -> int:
+    """計算序列尾端連續正值或負值的天數。"""
+
+    count = 0
+    for value in reversed(list(values)):
+        if positive and value > 0:
+            count += 1
+        elif (not positive) and value < 0:
+            count += 1
+        else:
+            break
+    return count
+
+
+def last_turning_point(series: pd.Series) -> Optional[pd.Timestamp]:
+    """取得最近一次正負號轉換的日期。"""
+
+    signs = np.sign(series.fillna(0).to_numpy())
+    if len(signs) < 2:
+        return None
+    for idx in range(len(signs) - 1, 0, -1):
+        if signs[idx] == 0:
+            continue
+        prev_idx = idx - 1
+        while prev_idx >= 0 and signs[prev_idx] == 0:
+            prev_idx -= 1
+        if prev_idx >= 0 and signs[idx] != signs[prev_idx]:
+            return series.index[idx]
+    return None
+
+
+def percentile_rank(values: pd.Series) -> pd.Series:
+    """計算 0–1 之間的百分位排名。"""
+
+    return values.rank(pct=True, method="average")
+
+
+def percent_change(series: pd.Series, periods: int) -> pd.Series:
+    """計算指定期數的百分比變化。"""
+
+    return series.pct_change(periods=periods)
+
+
+if __name__ == "__main__":  # pragma: no cover - 自行檢查
+    sample = pd.Series([1, 2, 3, 4, 5], index=pd.date_range("2024-01-01", periods=5))
+    slope = rolling_slope(sample, window=3)
+    assert slope.iloc[-1] > 0
+    assert consecutive_days([1, 2, -1, 3], positive=True) == 1
+    assert consecutive_days([1, 2, 3], positive=True) == 3
+    assert consecutive_days([-1, -2, -3], positive=False) == 3
+    print("utils 自測完成")


### PR DESCRIPTION
## Summary
- add an analysis package with data loading, indicator, chip, capital, fundamental, recommendation, and report modules
- implement a CLI entry point to orchestrate full stock analysis and generate CSV/Markdown/HTML outputs with optional charts
- integrate scoring heuristics and safeguards for missing data while logging warnings

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd9d3370fc832491db7d441f619483