### PR TITLE
Fix EnrichConfig dataclass defaults

### DIFF
--- a/finmind_fetch/enrich.py
+++ b/finmind_fetch/enrich.py
@@ -92,15 +92,15 @@ class EnrichConfig:
 
     input_path: Path
     output_path: Path
-    min_output_path: Path | None = None
-    fetch_fundamentals: bool
-    since: str | None
-    stocks: Sequence[str] | None
-    token: str | None
-    force_refresh: bool
-    strict: bool
+    fetch_fundamentals: bool = False
+    since: str | None = None
+    stocks: Sequence[str] | None = None
+    token: str | None = None
+    force_refresh: bool = False
+    strict: bool = False
     align_strategy: str = "forward_fill"
     cache_dir: Path | None = None
+    min_output_path: Path | None = None
     update_min: bool = True
 
 


### PR DESCRIPTION
## Summary
- add defaults to optional EnrichConfig fields so required fields precede defaults and match CLI expectations

## Testing
- python - <<'PY'
import sys, types
np_stub = types.SimpleNamespace(nan=float('nan'), inf=float('inf'))
sys.modules.setdefault('numpy', np_stub)
class _PandasStub(types.SimpleNamespace):
    def __init__(self):
        super().__init__(
            DataFrame=object,
            read_csv=lambda *args, **kwargs: None,
            to_datetime=lambda *args, **kwargs: None,
            read_parquet=lambda *args, **kwargs: None,
            to_numeric=lambda *args, **kwargs: None,
            concat=lambda *args, **kwargs: None,
            merge_asof=lambda *args, **kwargs: None,
            date_range=lambda *args, **kwargs: None,
            DataFrameRangeIndex=object,
        )
sys.modules.setdefault('pandas', _PandasStub())
class _Session:
    def get(self, *args, **kwargs):
        raise RuntimeError('stubbed requests session')
class _RequestsModule(types.SimpleNamespace):
    def __init__(self):
        super().__init__(Session=_Session, RequestException=Exception)
sys.modules.setdefault('requests', _RequestsModule())
import finmind_fetch.enrich as enrich
config = enrich.EnrichConfig(input_path='a', output_path='b')
print(config)
PY
- python -m finmind_fetch --help

------
https://chatgpt.com/codex/tasks/task_e_68ce4ac0e6108324b6c6786111e2c432