### PR TITLE
refactor: rebuild finmind etl pipeline

### DIFF
--- a/finmind_etl/api.py
+++ b/finmind_etl/api.py
@@ -1,0 +1,263 @@
+"""FinMind API 介面封裝模組。"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, Optional
+
+import pandas as pd
+import requests
+
+BASE_URL = "https://api.finmindtrade.com/api/v4"
+DATA_ENDPOINT = f"{BASE_URL}/data"
+TRANSLATION_ENDPOINT = f"{BASE_URL}/translation"
+DATALIST_ENDPOINT = f"{BASE_URL}/datalist"
+DEFAULT_TIMEOUT = 20
+DEFAULT_RETRIES = 3
+RATE_LIMIT_SLEEP = 0.15
+
+LOGGER = logging.getLogger("finmind_etl.api")
+
+
+class FinMindAPIError(RuntimeError):
+    """表示 FinMind API 回應失敗。"""
+
+
+@dataclass
+class APIClient:
+    """簡化的 FinMind API 用戶端。
+
+    Parameters
+    ----------
+    token:
+        FinMind API token。會優先以 Bearer header 附帶，若失敗再回退至
+        query string，符合官方建議的授權方式。
+    session:
+        重複使用的 :class:`requests.Session` 實例，可減少 TCP 開銷。
+    retries:
+        單一請求的最大重試次數。
+    timeout:
+        HTTP 請求逾時秒數。
+    backoff:
+        速率限制時的起始等待秒數，會以 2 的指數倍數增加。
+    """
+
+    token: Optional[str] = None
+    session: Optional[requests.Session] = None
+    retries: int = DEFAULT_RETRIES
+    timeout: int = DEFAULT_TIMEOUT
+    backoff: float = RATE_LIMIT_SLEEP
+
+    def __post_init__(self) -> None:
+        if self.session is None:
+            self.session = requests.Session()
+
+    # -- 核心請求邏輯 -------------------------------------------------
+
+    def request_json(self, endpoint: str, params: Dict[str, Any]) -> Dict[str, Any]:
+        """送出 GET 請求並回傳 JSON。
+
+        會自動附帶 Bearer token、實作指數退避與節流，確保在 API 回傳
+        ``status != 200`` 或 HTTP 錯誤時能夠重試。僅在成功時回傳字典，否則
+        拋出 :class:`FinMindAPIError`。
+        """
+
+        url = f"{BASE_URL}/{endpoint.lstrip('/')}"
+        effective_params = {k: v for k, v in params.items() if v not in (None, "")}
+        last_error: Optional[str] = None
+
+        # 依指示採用 Bearer header；若三次皆失敗再嘗試 query token。
+        use_header_first = bool(self.token)
+        attempts: Iterable[bool]
+        if use_header_first:
+            attempts = (True, False)
+        else:
+            attempts = (False,)
+
+        for header_first in attempts:
+            for attempt in range(1, self.retries + 1):
+                headers: Dict[str, str] = {}
+                params_to_use = dict(effective_params)
+                if self.token:
+                    if header_first:
+                        headers["Authorization"] = f"Bearer {self.token}"
+                    else:
+                        params_to_use["token"] = self.token
+
+                try:
+                    response = self.session.get(
+                        url,
+                        params=params_to_use,
+                        headers=headers,
+                        timeout=self.timeout,
+                    )
+                except requests.RequestException as exc:  # noqa: PERF203 - 需完整捕捉
+                    last_error = str(exc)
+                    self._sleep(attempt)
+                    continue
+
+                if response.status_code in {402, 429}:
+                    last_error = f"HTTP {response.status_code}: {response.text}"
+                    self._sleep(attempt)
+                    continue
+
+                if response.status_code != 200:
+                    last_error = f"HTTP {response.status_code}: {response.text}"
+                    if attempt == self.retries:
+                        break
+                    self._sleep(attempt)
+                    continue
+
+                try:
+                    payload = response.json()
+                except ValueError as exc:  # noqa: PERF203 - JSON 解析可能失敗
+                    last_error = f"JSON decode error: {exc}"
+                    self._sleep(attempt)
+                    continue
+
+                if not isinstance(payload, dict):
+                    last_error = f"Unexpected payload type: {type(payload)}"
+                    self._sleep(attempt)
+                    continue
+
+                status = payload.get("status")
+                if status != 200:
+                    message = str(payload.get("msg", "unknown error"))
+                    last_error = f"status={status} msg={message}"
+                    # FinMind 於額度不足時訊息通常會包含 limit
+                    if "limit" not in message.lower():
+                        # 對於非額度錯誤不需要重試
+                        break
+                    self._sleep(attempt)
+                    continue
+
+                data = payload.get("data")
+                if data is None or not isinstance(data, (list, dict)):
+                    raise FinMindAPIError("回傳資料格式異常：缺少 data")
+
+                time.sleep(RATE_LIMIT_SLEEP)
+                return payload
+
+            if last_error:
+                LOGGER.warning("授權模式 %s 失敗：%s", "header" if header_first else "query", last_error)
+
+        raise FinMindAPIError(last_error or "FinMind API 呼叫失敗")
+
+    # -- 高階封裝 -----------------------------------------------------
+
+    def fetch_dataset(
+        self,
+        dataset: str,
+        data_id: Optional[str],
+        start_date: Optional[str],
+        end_date: Optional[str],
+    ) -> pd.DataFrame:
+        """下載資料集並轉為 :class:`pandas.DataFrame`。"""
+
+        params: Dict[str, Any] = {"dataset": dataset}
+        if data_id:
+            params["data_id"] = data_id
+        if start_date:
+            params["start_date"] = start_date
+        if end_date:
+            params["end_date"] = end_date
+
+        payload = self.request_json("data", params)
+        data = payload.get("data")
+        if isinstance(data, list):
+            df = pd.DataFrame(data)
+        elif isinstance(data, dict):
+            df = pd.DataFrame([data])
+        else:  # 理論上不會到這裡，前面已檢查
+            raise FinMindAPIError("無法解析 API 回傳資料格式")
+
+        if not df.empty:
+            if "date" in df.columns:
+                df["date"] = pd.to_datetime(df["date"], errors="coerce")
+            if "stock_id" in df.columns:
+                df["stock_id"] = df["stock_id"].astype(str)
+        return df.sort_values([c for c in ["stock_id", "date"] if c in df.columns]).reset_index(drop=True)
+
+    def try_translation(self, dataset: str) -> Dict[str, str]:
+        """嘗試取得欄位翻譯。失敗時回傳空字典。"""
+
+        try:
+            payload = self.request_json("translation", {"dataset": dataset})
+        except FinMindAPIError as exc:
+            LOGGER.info("translation 取得失敗：dataset=%s %s", dataset, exc)
+            return {}
+        mapping: Dict[str, str] = {}
+        for item in payload.get("data", []):
+            raw = str(item.get("field") or item.get("origin_field") or "").strip()
+            english = str(
+                item.get("en")
+                or item.get("en_name")
+                or item.get("en-us")
+                or item.get("english")
+                or ""
+            ).strip()
+            if not raw or not english:
+                continue
+            mapping[raw] = english.replace("/", "_").replace(" ", "_").replace("-", "_").lower()
+        return mapping
+
+    def try_datalist(self, dataset: str) -> Dict[str, Any]:
+        """嘗試取得 dataset 說明。失敗時回傳空字典。"""
+
+        try:
+            payload = self.request_json("datalist", {"dataset": dataset})
+        except FinMindAPIError as exc:
+            LOGGER.info("datalist 取得失敗：dataset=%s %s", dataset, exc)
+            return {}
+        return payload
+
+    def _sleep(self, attempt: int) -> None:
+        delay = self.backoff * (2 ** (attempt - 1))
+        time.sleep(delay)
+
+
+def request_json(path: str, params: Dict[str, Any], token: Optional[str]) -> Dict[str, Any]:
+    """模組級封裝，方便舊程式呼叫。"""
+
+    client = APIClient(token=token)
+    endpoint = path.lstrip("/")
+    return client.request_json(endpoint, params)
+
+
+def fetch_dataset(
+    dataset: str,
+    data_id: Optional[str],
+    start_date: Optional[str],
+    end_date: Optional[str],
+    token: Optional[str],
+) -> pd.DataFrame:
+    """模組級封裝，提供與指示相符的函式介面。"""
+
+    client = APIClient(token=token)
+    return client.fetch_dataset(dataset, data_id, start_date, end_date)
+
+
+def try_translation(dataset: str, token: Optional[str]) -> Dict[str, str]:
+    """取得欄位翻譯。"""
+
+    client = APIClient(token=token)
+    return client.try_translation(dataset)
+
+
+def try_datalist(dataset: str, token: Optional[str]) -> Dict[str, Any]:
+    """取得 dataset 說明資訊。"""
+
+    client = APIClient(token=token)
+    return client.try_datalist(dataset)
+
+
+__all__ = [
+    "APIClient",
+    "FinMindAPIError",
+    "fetch_dataset",
+    "request_json",
+    "try_translation",
+    "try_datalist",
+]

--- a/finmind_etl/chip.py
+++ b/finmind_etl/chip.py
@@ -1,0 +1,181 @@
+"""籌碼面資料抓取模組。"""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, List, Optional, Sequence
+
+import numpy as np
+import pandas as pd
+
+from .api import APIClient
+from .technical import _apply_translation, _ensure_datetime, _ensure_stock_id, _numeric
+
+LOGGER = logging.getLogger("finmind_etl.chip")
+
+
+def _rename_with_candidates(df: pd.DataFrame, candidates: Dict[str, str]) -> pd.DataFrame:
+    rename_map: Dict[str, str] = {}
+    for column in df.columns:
+        lower = column.lower()
+        for pattern, target in candidates.items():
+            if pattern in lower:
+                rename_map[column] = target
+                break
+    if rename_map:
+        df = df.rename(columns=rename_map)
+    return df
+
+
+def fetch_institutional(
+    stocks: Sequence[str],
+    client: APIClient,
+    start: str,
+    end: str,
+) -> pd.DataFrame:
+    """抓取三大法人買賣超資料。"""
+
+    translation = client.try_translation("TaiwanStockInstitutionalInvestorsBuySell")
+    frames: List[pd.DataFrame] = []
+    for stock in stocks:
+        try:
+            df = client.fetch_dataset(
+                "TaiwanStockInstitutionalInvestorsBuySell",
+                stock,
+                start,
+                end,
+            )
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.warning("法人資料抓取失敗：%s %s", stock, exc)
+            continue
+        if df.empty:
+            continue
+        df = _apply_translation(df, translation)
+        df = _ensure_datetime(df)
+        df = _ensure_stock_id(df)
+        df = _rename_with_candidates(
+            df,
+            {
+                "foreign_investor_net": "foreign_net",
+                "foreign_net_buy_sell": "foreign_net",
+                "foreign": "foreign_net",
+                "investment_trust_net": "invest_trust_net",
+                "investment_trust": "invest_trust_net",
+                "dealer_self": "dealer_self_net",
+                "dealer_hedging": "dealer_hedging_net",
+                "dealer_net": "dealer_net",
+                "dealer": "dealer_net",
+            },
+        )
+        frames.append(df)
+    if not frames:
+        columns = [
+            "date",
+            "stock_id",
+            "foreign_net",
+            "invest_trust_net",
+            "dealer_net",
+            "dealer_self_net",
+            "dealer_hedging_net",
+        ]
+        return pd.DataFrame(columns=columns)
+    merged = pd.concat(frames, ignore_index=True)
+    numeric_columns = [
+        "foreign_net",
+        "invest_trust_net",
+        "dealer_net",
+        "dealer_self_net",
+        "dealer_hedging_net",
+    ]
+    _numeric(merged, numeric_columns)
+    merged = merged.sort_values(["stock_id", "date"]).reset_index(drop=True)
+    for column in numeric_columns:
+        if column not in merged.columns:
+            merged[column] = np.nan
+    return merged[["date", "stock_id", *numeric_columns]]
+
+
+def fetch_margin_short(
+    stocks: Sequence[str],
+    client: APIClient,
+    start: str,
+    end: str,
+) -> pd.DataFrame:
+    """抓取融資融券資料。"""
+
+    translation = client.try_translation("TaiwanStockMarginPurchaseShortSale")
+    frames: List[pd.DataFrame] = []
+    for stock in stocks:
+        try:
+            df = client.fetch_dataset(
+                "TaiwanStockMarginPurchaseShortSale",
+                stock,
+                start,
+                end,
+            )
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.warning("融資融券抓取失敗：%s %s", stock, exc)
+            continue
+        if df.empty:
+            continue
+        df = _apply_translation(df, translation)
+        df = _ensure_datetime(df)
+        df = _ensure_stock_id(df)
+        df = _rename_with_candidates(
+            df,
+            {
+                "margin_purchase_today_balance": "margin_long",
+                "margin_purchase_change": "margin_long_change",
+                "short_sale_today_balance": "margin_short",
+                "short_sale_change": "margin_short_change",
+                "short_sale_volume": "short_selling",
+                "short_sale": "short_selling",
+            },
+        )
+        frames.append(df)
+    if not frames:
+        columns = [
+            "date",
+            "stock_id",
+            "margin_long",
+            "margin_short",
+            "margin_long_change",
+            "margin_short_change",
+            "short_selling",
+        ]
+        return pd.DataFrame(columns=columns)
+    merged = pd.concat(frames, ignore_index=True)
+    numeric_columns = [
+        "margin_long",
+        "margin_short",
+        "margin_long_change",
+        "margin_short_change",
+        "short_selling",
+    ]
+    _numeric(merged, numeric_columns)
+    merged = merged.sort_values(["stock_id", "date"]).reset_index(drop=True)
+    for column in numeric_columns:
+        if column not in merged.columns:
+            merged[column] = np.nan
+    return merged[["date", "stock_id", *numeric_columns]]
+
+
+def fetch_chip_data(
+    stocks: Sequence[str],
+    since: str,
+    client: APIClient,
+    end_date: Optional[str] = None,
+) -> Dict[str, pd.DataFrame]:
+    """取得籌碼面資料。"""
+
+    end = end_date or pd.Timestamp.today().strftime("%Y-%m-%d")
+    LOGGER.info("抓取籌碼面資料：股票數量=%s", len(stocks))
+    institutional = fetch_institutional(stocks, client, since, end)
+    margin = fetch_margin_short(stocks, client, since, end)
+    return {
+        "TaiwanStockInstitutionalInvestorsBuySell": institutional,
+        "TaiwanStockMarginPurchaseShortSale": margin,
+    }
+
+
+__all__ = ["fetch_chip_data", "fetch_institutional", "fetch_margin_short"]

--- a/finmind_etl/cli.py
+++ b/finmind_etl/cli.py
@@ -1,256 +1,116 @@
-"""指令列介面與流程控制。"""
+"""指令列介面：串接 FinMind API 並輸出寬表。"""
 
 from __future__ import annotations
 
 import argparse
-import os
-from typing import Dict, List
+import logging
+from pathlib import Path
+from typing import Dict, Iterable, List
 
-import numpy as np
 import pandas as pd
 
-from .config import (
-    DEFAULT_DATASETS,
-    DEFAULT_MERGE,
-    DEFAULT_OUTDIR,
-    DEFAULT_RATE_LIMIT_SLEEP,
-    DEFAULT_RETRIES,
-    DEFAULT_STOCKS,
-    ERROR_LOGGER,
-    LOGGER,
-    configure_logging,
-    default_end_date,
-    default_start_date,
-)
-from .datasets import DATASET_CATALOG, DATASET_FILENAME_TAG
-from .fetcher import FetchError, build_session, fetch_dataset
-from .io_utils import _read_raw_merged, save_frame
-from .merger import (
-    _build_institutional_wide,
-    _extract_price_block,
-    _merge_daily_wide,
-    _normalize_types,
-    merge_frames,
-)
-from .normalizers import NORMALIZERS
-from .summarize import _print_summary
+from .api import APIClient
+from .chip import fetch_chip_data
+from .derivative import fetch_derivative_data
+from .enrich import build_daily_wide, build_minimal_view
+from .fundamentals import fetch_fundamental_data
+from .technical import fetch_technical_data
+
+LOGGER = logging.getLogger("finmind_etl.cli")
 
 
-def parse_arguments() -> argparse.Namespace:
-    """解析指令列參數。"""
-
-    parser = argparse.ArgumentParser(description="FinMind 日資料批次下載工具")
-    parser.add_argument("--token", default="", help="FinMind token，可留空")
-    parser.add_argument(
-        "--stocks",
-        default=DEFAULT_STOCKS,
-        help="股票代號清單，以逗號分隔",
+def configure_logging() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(levelname)s - %(message)s",
     )
-    parser.add_argument(
-        "--start",
-        default=default_start_date(),
-        help="起始日期 (YYYY-MM-DD)",
-    )
-    parser.add_argument(
-        "--end",
-        default=default_end_date(),
-        help="結束日期 (YYYY-MM-DD)",
-    )
-    parser.add_argument(
-        "--datasets",
-        default=DEFAULT_DATASETS,
-        help="欲下載的資料集，以逗號分隔",
-    )
-    parser.add_argument(
-        "--outdir",
-        default=DEFAULT_OUTDIR,
-        help="輸出資料夾",
-    )
-    parser.add_argument(
-        "--parquet",
-        action="store_true",
-        help="是否同時輸出 Parquet",
-    )
-    parser.add_argument(
-        "--merge",
-        dest="merge",
-        action="store_true",
-        default=DEFAULT_MERGE,
-        help="是否輸出合併寬表 (預設開啟)",
-    )
-    parser.add_argument(
-        "--no-merge",
-        dest="merge",
-        action="store_false",
-        help="停用合併寬表輸出",
-    )
-    parser.add_argument(
-        "--rate-limit-sleep",
-        type=float,
-        default=DEFAULT_RATE_LIMIT_SLEEP,
-        help="遭遇速率限制時的初始等待秒數",
-    )
-    parser.add_argument(
-        "--retries",
-        type=int,
-        default=DEFAULT_RETRIES,
-        help="同一請求的最大重試次數",
-    )
-    return parser.parse_args()
 
 
-def main() -> None:
-    """程式進入點。"""
+def parse_arguments(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    """解析 CLI 參數。"""
 
-    args = parse_arguments()
-    configure_logging(args.outdir)
+    parser = argparse.ArgumentParser(description="FinMind v4 台股資料彙整工具")
+    parser.add_argument("--tickers", required=True, help="股票代號，逗號分隔")
+    parser.add_argument("--since", required=True, help="起始日期 (YYYY-MM-DD)")
+    parser.add_argument("--finmind-token", dest="token", help="FinMind API token")
+    parser.add_argument("--outdir", default="./finmind_out", help="輸出資料夾")
+    parser.add_argument("--end", help="結束日期，預設為今日")
+    return parser.parse_args(argv)
 
-    token = args.token.strip() or None
-    if token:
-        LOGGER.info("使用提供的 token 以提升速率限制。")
-    else:
-        LOGGER.warning("未提供 token，每小時可用額度較低，建議提供 token。")
 
-    stocks = [code.strip() for code in args.stocks.split(",") if code.strip()]
-    datasets = [name.strip() for name in args.datasets.split(",") if name.strip()]
+def _parse_tickers(value: str) -> List[str]:
+    tickers = [item.strip() for item in value.split(",") if item.strip()]
+    return [ticker.zfill(4) for ticker in tickers]
 
-    session = build_session()
 
-    aggregated_frames: Dict[str, List[pd.DataFrame]] = {name: [] for name in datasets}
+def _snake_case(value: str) -> str:
+    import re
 
-    for dataset in datasets:
-        if dataset not in DATASET_CATALOG:
-            LOGGER.error("資料集 %s 未在 DATASET_CATALOG 中定義，跳過。", dataset)
+    text = re.sub(r"[^0-9A-Za-z]+", "_", value.strip())
+    text = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", text)
+    return re.sub(r"_+", "_", text).strip("_").lower()
+
+
+def _write_dataframe(df: pd.DataFrame, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    export = df.copy()
+    if "date" in export.columns:
+        export["date"] = pd.to_datetime(export["date"], errors="coerce").dt.strftime("%Y-%m-%d")
+    export.to_csv(path, index=False, encoding="utf-8")
+    LOGGER.info("輸出 %s 筆資料至 %s", len(export), path)
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    args = parse_arguments(argv)
+    configure_logging()
+
+    tickers = _parse_tickers(args.tickers)
+    if not tickers:
+        raise SystemExit("請至少提供一檔股票代號")
+
+    LOGGER.info("目標股票：%s", tickers)
+    client = APIClient(token=args.token)
+
+    technical = fetch_technical_data(tickers, args.since, client, end_date=args.end)
+    fundamentals = fetch_fundamental_data(tickers, args.since, client, end_date=args.end)
+    chip = fetch_chip_data(tickers, args.since, client, end_date=args.end)
+    derivative = fetch_derivative_data(tickers, args.since, client, end_date=args.end)
+
+    outdir = Path(args.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    raw_frames: Dict[str, pd.DataFrame] = {}
+    raw_frames.update(technical)
+    raw_frames.update(fundamentals)
+    raw_frames.update(chip)
+    raw_frames.update(derivative)
+
+    for dataset, df in raw_frames.items():
+        if df is None:
             continue
+        safe_name = _snake_case(dataset)
+        path = outdir / f"raw_{safe_name}.csv"
+        _write_dataframe(df, path)
 
-        for stock in stocks:
-            LOGGER.info(
-                "開始下載 dataset=%s, stock_id=%s, 區間=%s~%s",
-                dataset,
-                stock,
-                args.start,
-                args.end,
-            )
-            requires_stock = DATASET_CATALOG[dataset].get("requires_stock", True)
-            stock_id = stock if requires_stock else None
-            try:
-                raw_df = fetch_dataset(
-                    session=session,
-                    dataset=dataset,
-                    stock_id=stock_id,
-                    start=args.start,
-                    end=args.end,
-                    token=token,
-                    rate_limit_sleep=args.rate_limit_sleep,
-                    retries=args.retries,
-                )
-            except FetchError as exc:
-                ERROR_LOGGER.error(
-                    "%s", exc,
-                    exc_info=False,
-                )
-                continue
+    daily_wide = build_daily_wide(tickers, technical, fundamentals, chip, derivative)
+    if daily_wide.empty:
+        LOGGER.warning("合併後資料為空，請檢查輸入參數或 API 回應。")
+        return
 
-            normalizer = NORMALIZERS.get(dataset)
-            if not normalizer:
-                LOGGER.error("資料集 %s 缺少對應的清洗函式。", dataset)
-                continue
+    wide_path = outdir / "_clean_daily_wide.csv"
+    _write_dataframe(daily_wide, wide_path)
 
-            cleaned_df = normalizer(raw_df)
-            if cleaned_df.empty:
-                LOGGER.warning("dataset=%s, stock_id=%s 無資料。", dataset, stock)
+    wide_min = build_minimal_view(daily_wide)
+    min_path = outdir / "_clean_daily_wide_min.csv"
+    _write_dataframe(wide_min, min_path)
 
-            aggregated_frames.setdefault(dataset, []).append(cleaned_df)
-
-            dataset_dir = os.path.join(args.outdir, dataset)
-            tag = DATASET_FILENAME_TAG.get(dataset, dataset.lower())
-            csv_path = os.path.join(dataset_dir, f"{stock}_{tag}.csv")
-            parquet_path = (
-                os.path.join(dataset_dir, f"{stock}_{tag}.parquet")
-                if args.parquet
-                else None
-            )
-            save_frame(cleaned_df, csv_path, parquet_path)
-
-    dataset_frames: Dict[str, pd.DataFrame] = {}
-    for dataset, frames in aggregated_frames.items():
-        if not frames:
-            dataset_frames[dataset] = pd.DataFrame()
-            continue
-        dataset_frames[dataset] = (
-            pd.concat(frames, ignore_index=True)
-            .sort_values(["stock_id", "date"])
-            .reset_index(drop=True)
-        )
-
-    if args.merge:
-        LOGGER.info("開始合併所有資料集。")
-        merged_df = merge_frames(dataset_frames)
-        merged_csv = os.path.join(args.outdir, "_merged.csv")
-        merged_parquet = (
-            os.path.join(args.outdir, "_merged.parquet") if args.parquet else None
-        )
-        save_frame(merged_df, merged_csv, merged_parquet)
-    else:
-        LOGGER.info("使用者設定不輸出合併寬表。")
-
-    external_merged_path = os.path.join(args.outdir, "_merged.csv")
-    if os.path.exists(external_merged_path):
-        LOGGER.info("偵測到 %s，開始整理每日寬表。", external_merged_path)
-        raw_external = _read_raw_merged(external_merged_path)
-
-        if raw_external.empty:
-            LOGGER.warning("外部合併檔案無資料，跳過每日寬表清理。")
-        else:
-            normalized = _normalize_types(raw_external)
-            price_block = _extract_price_block(normalized)
-            inst_block = _build_institutional_wide(normalized)
-            merged_daily = _merge_daily_wide(price_block, inst_block)
-            if merged_daily.empty:
-                LOGGER.warning("合併後資料為空，無法輸出每日寬表。")
-            else:
-                merged_daily = merged_daily.sort_values(["date", "stock_id"]).reset_index(drop=True)
-
-                display_df = merged_daily.copy()
-                if "date" in display_df.columns:
-                    date_series = pd.to_datetime(display_df["date"], errors="coerce")
-                    display_df["date"] = date_series.dt.strftime("%Y-%m-%d")
-                _print_summary(display_df)
-
-                output_path = os.path.join(args.outdir, "_clean_daily_wide.csv")
-                output_min_path = os.path.join(args.outdir, "_clean_daily_wide_min.csv")
+    LOGGER.info(
+        "完成：列數=%s 股票數=%s 日期範圍=%s~%s",
+        len(daily_wide),
+        daily_wide["stock_id"].nunique(),
+        daily_wide["date"].min().strftime("%Y-%m-%d"),
+        daily_wide["date"].max().strftime("%Y-%m-%d"),
+    )
 
 
-                export_df = merged_daily.copy()
-                if "date" in export_df.columns:
-                    date_series = pd.to_datetime(export_df["date"], errors="coerce")
-                    export_df["date"] = date_series.dt.strftime("%Y-%m-%d")
-
-                required_min_columns = [
-                    "date",
-                    "stock_id",
-                    "open",
-                    "high",
-                    "low",
-                    "close",
-                    "volume",
-                    "turnover",
-                    "inst_foreign",
-                    "inst_investment_trust",
-                    "inst_dealer_self",
-                    "inst_dealer_hedging",
-                ]
-                for column in required_min_columns:
-                    if column not in export_df.columns:
-                        export_df[column] = np.nan
-
-                export_df.to_csv(output_path, index=False, encoding="utf-8")
-                export_df[required_min_columns].to_csv(
-                    output_min_path, index=False, encoding="utf-8"
-                )
-                LOGGER.info("每日寬表已輸出至 %s 與 %s。", output_path, output_min_path)
-    else:
-        LOGGER.info("未偵測到 %s，跳過每日寬表清理。", external_merged_path)
-
-
-__all__ = ["parse_arguments", "main"]
+__all__ = ["main", "parse_arguments"]

--- a/finmind_etl/derivative.py
+++ b/finmind_etl/derivative.py
@@ -1,0 +1,101 @@
+"""衍生性商品資料抓取模組。"""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, Optional, Sequence
+
+import pandas as pd
+
+from .api import APIClient
+from .technical import _apply_translation, _ensure_datetime, _to_snake_case
+
+LOGGER = logging.getLogger("finmind_etl.derivative")
+
+
+def _prefix_columns(df: pd.DataFrame, prefix: str, exclude: Sequence[str]) -> pd.DataFrame:
+    rename_map = {
+        column: f"{prefix}{_to_snake_case(column)}"
+        for column in df.columns
+        if column not in exclude
+    }
+    return df.rename(columns=rename_map)
+
+
+def _ensure_numeric_all(df: pd.DataFrame, exclude: Sequence[str]) -> None:
+    for column in df.columns:
+        if column in exclude:
+            continue
+        df[column] = pd.to_numeric(df[column], errors="coerce")
+
+
+def fetch_futures_data(
+    client: APIClient,
+    start: str,
+    end: str,
+    contract: str = "TX",
+) -> pd.DataFrame:
+    """抓取期貨三大法人資料。"""
+
+    try:
+        df = client.fetch_dataset("TaiwanFuturesInstitutionalInvestors", contract, start, end)
+    except Exception as exc:  # noqa: BLE001
+        LOGGER.warning("期貨資料抓取失敗：%s", exc)
+        return pd.DataFrame(columns=["date"])
+    if df.empty:
+        return pd.DataFrame(columns=["date"])
+    translation = client.try_translation("TaiwanFuturesInstitutionalInvestors")
+    df = _apply_translation(df, translation)
+    df = _ensure_datetime(df)
+    df = _prefix_columns(df, "fut_", ["date", "stock_id", "contract", "code"])
+    _ensure_numeric_all(df, ["date", "contract", "code", "stock_id"])
+    df = df.drop(columns=[col for col in df.columns if col.endswith("contract") or col.endswith("code")], errors="ignore")
+    df = df.sort_values("date").reset_index(drop=True)
+    return df
+
+
+def fetch_option_data(
+    client: APIClient,
+    start: str,
+    end: str,
+    contract: str = "TXO",
+) -> pd.DataFrame:
+    """抓取選擇權三大法人資料。"""
+
+    try:
+        df = client.fetch_dataset("TaiwanOptionInstitutionalInvestors", contract, start, end)
+    except Exception as exc:  # noqa: BLE001
+        LOGGER.warning("選擇權資料抓取失敗：%s", exc)
+        return pd.DataFrame(columns=["date"])
+    if df.empty:
+        return pd.DataFrame(columns=["date"])
+    translation = client.try_translation("TaiwanOptionInstitutionalInvestors")
+    df = _apply_translation(df, translation)
+    df = _ensure_datetime(df)
+    df = _prefix_columns(df, "opt_", ["date", "stock_id", "contract", "code"])
+    _ensure_numeric_all(df, ["date", "contract", "code", "stock_id"])
+    df = df.drop(columns=[col for col in df.columns if col.endswith("contract") or col.endswith("code")], errors="ignore")
+    df = df.sort_values("date").reset_index(drop=True)
+    return df
+
+
+def fetch_derivative_data(
+    stocks: Sequence[str],
+    since: str,
+    client: APIClient,
+    end_date: Optional[str] = None,
+) -> Dict[str, pd.DataFrame]:
+    """取得衍生性商品資料。"""
+
+    del stocks  # 衍生性資料多為指數層級，暫不區分個股
+    end = end_date or pd.Timestamp.today().strftime("%Y-%m-%d")
+    LOGGER.info("抓取衍生性資料")
+    futures = fetch_futures_data(client, since, end)
+    options = fetch_option_data(client, since, end)
+    return {
+        "TaiwanFuturesInstitutionalInvestors": futures,
+        "TaiwanOptionInstitutionalInvestors": options,
+    }
+
+
+__all__ = ["fetch_derivative_data"]

--- a/finmind_etl/enrich.py
+++ b/finmind_etl/enrich.py
@@ -1,0 +1,208 @@
+"""資料集整併與寬表產生模組。"""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, Iterable, List, Optional, Sequence
+
+import numpy as np
+import pandas as pd
+
+LOGGER = logging.getLogger("finmind_etl.enrich")
+
+
+def _build_trading_index(
+    stocks: Sequence[str],
+    calendar: pd.DataFrame,
+    price: pd.DataFrame,
+) -> pd.DataFrame:
+    """依交易日曆建立股票 x 日期的基底。"""
+
+    stocks = sorted({s.zfill(4) for s in stocks})
+    if calendar is not None and not calendar.empty:
+        calendar = calendar.copy()
+        if "is_trading_day" in calendar.columns:
+            calendar = calendar[calendar["is_trading_day"].astype(int) == 1]
+        if "date" not in calendar.columns:
+            raise ValueError("交易日曆缺少 date 欄位")
+        dates = pd.to_datetime(calendar["date"], errors="coerce").dropna().dt.normalize()
+    else:
+        LOGGER.warning("交易日曆為空，改用股價資料中的日期集合。")
+        dates = pd.to_datetime(price.get("date"), errors="coerce").dropna().dt.normalize()
+    dates = sorted(dates.unique())
+    if not dates:
+        return pd.DataFrame(columns=["stock_id", "date"])
+    index = pd.MultiIndex.from_product([stocks, dates], names=["stock_id", "date"])
+    base = index.to_frame(index=False)
+    base["date"] = pd.to_datetime(base["date"], utc=False)
+    return base
+
+
+def _merge_with_forward_fill(
+    base: pd.DataFrame,
+    df: pd.DataFrame,
+    columns: Iterable[str],
+    forward_fill: bool = True,
+) -> pd.DataFrame:
+    """將附加資料合併到基底，必要時進行前值延展。"""
+
+    if df is None or df.empty:
+        for column in columns:
+            if column not in base.columns:
+                base[column] = np.nan
+        return base
+    merged = base.merge(df, on=["stock_id", "date"], how="left")
+    value_columns = [col for col in columns if col not in {"stock_id", "date"}]
+    if forward_fill and value_columns:
+        # 財報與籌碼資料皆可能非日頻，採前值延展以維持每日資料連續性。
+        merged[value_columns] = merged.groupby("stock_id")[value_columns].ffill()
+    return merged
+
+
+def _merge_date_level(base: pd.DataFrame, df: pd.DataFrame) -> pd.DataFrame:
+    if df is None or df.empty:
+        return base
+    value_columns = [col for col in df.columns if col != "date"]
+    merged = base.merge(df, on="date", how="left")
+    if value_columns:
+        merged[value_columns] = merged[value_columns].ffill()
+    return merged
+
+
+def build_daily_wide(
+    stocks: Sequence[str],
+    technical: Dict[str, pd.DataFrame],
+    fundamentals: Dict[str, pd.DataFrame],
+    chip: Dict[str, pd.DataFrame],
+    derivative: Dict[str, pd.DataFrame],
+) -> pd.DataFrame:
+    """整併所有資料集並產生每日寬表。"""
+
+    price = technical.get("TaiwanStockPrice", pd.DataFrame())
+    calendar = technical.get("TaiwanStockTradingDate", pd.DataFrame())
+    info = technical.get("TaiwanStockInfo", pd.DataFrame())
+    base = _build_trading_index(stocks, calendar, price)
+    if base.empty:
+        return base
+
+    if not price.empty:
+        price = price.copy()
+        price_cols = [col for col in price.columns if col not in {"date", "stock_id"}]
+        base = base.merge(price, on=["stock_id", "date"], how="left")
+    else:
+        LOGGER.warning("股價資料為空，寬表僅包含其他欄位。")
+
+    price_adj = technical.get("TaiwanStockPriceAdj")
+    if price_adj is not None and not price_adj.empty:
+        adj = price_adj.copy()
+        rename_map = {
+            column: f"adj_{column}" if column not in {"date", "stock_id"} else column
+            for column in adj.columns
+        }
+        adj = adj.rename(columns=rename_map)
+        adj_columns = [col for col in adj.columns if col not in {"date", "stock_id"}]
+        base = base.merge(adj, on=["stock_id", "date"], how="left")
+        for column in adj_columns:
+            base[column] = pd.to_numeric(base[column], errors="coerce")
+
+    # 籌碼資料（法人、融資融券）以前值延展補齊
+    for dataset, df in chip.items():
+        if df is None:
+            continue
+        columns = [col for col in df.columns if col not in {"stock_id", "date"}]
+        base = _merge_with_forward_fill(base, df, ["stock_id", "date", *columns], forward_fill=True)
+
+    # 基本面資料為月/季頻率，使用前值延展至下一次公告日
+    for dataset, df in fundamentals.items():
+        if df is None:
+            continue
+        columns = [col for col in df.columns if col not in {"stock_id", "date"}]
+        base = _merge_with_forward_fill(base, df, ["stock_id", "date", *columns], forward_fill=True)
+
+    # 衍生性資料僅以日期為索引
+    for dataset, df in derivative.items():
+        if df is None:
+            continue
+        base = _merge_date_level(base, df)
+
+    # 追加股票基本資訊
+    if info is not None and not info.empty:
+        info = info.copy()
+        keep_cols = [col for col in info.columns if col in {"stock_id", "industry_category", "stock_name"}]
+        if keep_cols:
+            base = base.merge(info[keep_cols].drop_duplicates(subset=["stock_id"]), on="stock_id", how="left")
+
+    # 衍生欄位計算
+    if "close" in base.columns:
+        base = base.sort_values(["stock_id", "date"]).reset_index(drop=True)
+        base["return"] = base.groupby("stock_id")["close"].pct_change()
+
+    if "turnover" in base.columns:
+        base["turnover_rank_pct"] = (
+            base.groupby("date")["turnover"].rank(method="average", pct=True)
+        ).clip(0, 1)
+        turnover_ma20 = (
+            base.groupby("stock_id")["turnover"].transform(lambda s: s.rolling(window=20, min_periods=5).mean())
+        )
+        base["turnover_change_vs_ma20"] = base["turnover"] / turnover_ma20 - 1
+        base["turnover_change_vs_ma20"] = base["turnover_change_vs_ma20"].replace([np.inf, -np.inf], np.nan)
+
+    if "volume" in base.columns:
+        base["volume_rank_pct"] = (
+            base.groupby("date")["volume"].rank(method="average", pct=True)
+        ).clip(0, 1)
+        base["volume_ma20"] = (
+            base.groupby("stock_id")["volume"].transform(lambda s: s.rolling(window=20, min_periods=5).mean())
+        )
+        base["volume_ratio"] = base["volume"] / base["volume_ma20"]
+        base["volume_ratio"] = base["volume_ratio"].replace([np.inf, -np.inf], np.nan)
+
+    if "transactions" in base.columns:
+        transactions_ma20 = (
+            base.groupby("stock_id")["transactions"].transform(lambda s: s.rolling(window=20, min_periods=5).mean())
+        )
+        base["transactions_change_vs_ma20"] = base["transactions"] / transactions_ma20 - 1
+        base["transactions_change_vs_ma20"] = base["transactions_change_vs_ma20"].replace([np.inf, -np.inf], np.nan)
+
+    base = base.sort_values(["date", "stock_id"]).reset_index(drop=True)
+    return base
+
+
+def build_minimal_view(df: pd.DataFrame) -> pd.DataFrame:
+    """建立精簡版寬表。"""
+
+    min_columns = [
+        "date",
+        "stock_id",
+        "open",
+        "high",
+        "low",
+        "close",
+        "volume",
+        "turnover",
+        "return",
+        "foreign_net",
+        "invest_trust_net",
+        "dealer_net",
+        "dealer_self_net",
+        "dealer_hedging_net",
+        "margin_long",
+        "margin_short",
+        "short_selling",
+        "revenue",
+        "revenue_yoy",
+        "revenue_mom",
+        "eps",
+        "eps_ttm",
+        "volume_ma20",
+        "volume_ratio",
+        "turnover_rank_pct",
+        "volume_rank_pct",
+    ]
+    for column in min_columns:
+        if column not in df.columns:
+            df[column] = np.nan
+    return df[min_columns].copy()
+
+
+__all__ = ["build_daily_wide", "build_minimal_view"]

--- a/finmind_etl/fundamentals.py
+++ b/finmind_etl/fundamentals.py
@@ -1,0 +1,146 @@
+"""基本面資料下載與整理。"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date
+from typing import Dict, List, Optional, Sequence
+
+import numpy as np
+import pandas as pd
+
+from .api import APIClient
+from .technical import _apply_translation, _ensure_datetime, _ensure_stock_id, _numeric, _to_snake_case
+
+LOGGER = logging.getLogger("finmind_etl.fundamentals")
+
+
+def _default_start(since: str, months: int = 18) -> str:
+    base = pd.to_datetime(since, errors="coerce")
+    if pd.isna(base):
+        base = pd.Timestamp.today() - pd.DateOffset(months=months)
+    else:
+        base = base - pd.DateOffset(months=months)
+    return base.strftime("%Y-%m-%d")
+
+
+def fetch_month_revenue(
+    stocks: Sequence[str],
+    since: str,
+    client: APIClient,
+    end_date: Optional[str] = None,
+) -> pd.DataFrame:
+    """抓取月營收資料。"""
+
+    start = _default_start(since, months=13)
+    end = end_date or date.today().strftime("%Y-%m-%d")
+    translation = client.try_translation("TaiwanStockMonthRevenue")
+    frames: List[pd.DataFrame] = []
+    for stock in stocks:
+        try:
+            df = client.fetch_dataset("TaiwanStockMonthRevenue", stock, start, end)
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.warning("月營收抓取失敗：%s %s", stock, exc)
+            continue
+        if df.empty:
+            continue
+        df = _apply_translation(df, translation)
+        df = _ensure_datetime(df)
+        df = _ensure_stock_id(df)
+        frames.append(df)
+    if not frames:
+        return pd.DataFrame(columns=["stock_id", "date", "revenue"])
+    merged = pd.concat(frames, ignore_index=True)
+    merged = merged.sort_values(["stock_id", "date"]).reset_index(drop=True)
+    merged = merged.rename(columns={"revenue_last_year": "revenue_prev_year", "revenue_last_month": "revenue_prev_month"})
+    _numeric(
+        merged,
+        [
+            "revenue",
+            "revenue_prev_year",
+            "revenue_prev_month",
+            "accumulated_revenue",
+            "accumulated_revenue_last_year",
+        ],
+    )
+    if "revenue_month" not in merged.columns and "date" in merged.columns:
+        merged["revenue_month"] = merged["date"].dt.month
+    if "revenue_year" not in merged.columns and "date" in merged.columns:
+        merged["revenue_year"] = merged["date"].dt.year
+    merged["revenue_yoy"] = merged.groupby("stock_id")["revenue"].pct_change(periods=12)
+    merged["revenue_mom"] = merged.groupby("stock_id")["revenue"].pct_change()
+    merged[["revenue_yoy", "revenue_mom"]] = merged[["revenue_yoy", "revenue_mom"]].replace([np.inf, -np.inf], np.nan)
+    if "country" not in merged.columns:
+        merged["country"] = "TW"
+    return merged
+
+
+def fetch_financial_statements(
+    stocks: Sequence[str],
+    since: str,
+    client: APIClient,
+    end_date: Optional[str] = None,
+) -> pd.DataFrame:
+    """抓取財報資料並提取 EPS。"""
+
+    start = _default_start(since, months=24)
+    end = end_date or date.today().strftime("%Y-%m-%d")
+    translation = client.try_translation("TaiwanStockFinancialStatements")
+    frames: List[pd.DataFrame] = []
+    for stock in stocks:
+        try:
+            df = client.fetch_dataset("TaiwanStockFinancialStatements", stock, start, end)
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.warning("財報抓取失敗：%s %s", stock, exc)
+            continue
+        if df.empty:
+            continue
+        df = _apply_translation(df, translation)
+        df.columns = [_to_snake_case(col) for col in df.columns]
+        if "type" not in df.columns:
+            candidate = next((col for col in ("origin_name", "name", "report_type") if col in df.columns), None)
+            if candidate:
+                df["type"] = df[candidate]
+        if "value" not in df.columns:
+            candidate = next((col for col in ("amount", "val", "data_value") if col in df.columns), None)
+            if candidate:
+                df["value"] = df[candidate]
+        if "type" not in df.columns or "value" not in df.columns:
+            LOGGER.warning("財報缺少必要欄位：%s", stock)
+            continue
+        df["type"] = df["type"].astype(str).str.lower()
+        df = df[df["type"].str.contains("eps", case=False, na=False)]
+        if df.empty:
+            continue
+        df = _ensure_datetime(df)
+        df = _ensure_stock_id(df)
+        df["value"] = pd.to_numeric(df["value"], errors="coerce")
+        frames.append(df[["stock_id", "date", "value"]])
+    if not frames:
+        return pd.DataFrame(columns=["stock_id", "date", "eps"])
+    combined = pd.concat(frames, ignore_index=True)
+    combined = combined.sort_values(["stock_id", "date"]).reset_index(drop=True)
+    combined = combined.rename(columns={"value": "eps"})
+    combined["eps_ttm"] = combined.groupby("stock_id")["eps"].transform(lambda s: s.rolling(window=4, min_periods=1).sum())
+    return combined
+
+
+def fetch_fundamental_data(
+    stocks: Sequence[str],
+    since: str,
+    client: APIClient,
+    end_date: Optional[str] = None,
+) -> Dict[str, pd.DataFrame]:
+    """取得基本面相關資料集。"""
+
+    end = end_date or date.today().strftime("%Y-%m-%d")
+    LOGGER.info("抓取基本面資料：股票數量=%s", len(stocks))
+    month_revenue = fetch_month_revenue(stocks, since, client, end)
+    financial = fetch_financial_statements(stocks, since, client, end)
+    return {
+        "TaiwanStockMonthRevenue": month_revenue,
+        "TaiwanStockFinancialStatements": financial,
+    }
+
+
+__all__ = ["fetch_fundamental_data", "fetch_month_revenue", "fetch_financial_statements"]

--- a/finmind_etl/technical.py
+++ b/finmind_etl/technical.py
@@ -1,0 +1,169 @@
+"""技術面資料抓取模組。"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date
+from typing import Dict, Iterable, List, Optional, Sequence
+
+import numpy as np
+import pandas as pd
+
+from .api import APIClient
+
+LOGGER = logging.getLogger("finmind_etl.technical")
+
+
+def _to_snake_case(value: str) -> str:
+    import re
+
+    text = re.sub(r"[^0-9A-Za-z]+", "_", value.strip())
+    text = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", text)
+    text = re.sub(r"_+", "_", text)
+    return text.strip("_").lower()
+
+
+def _apply_translation(df: pd.DataFrame, translation: Dict[str, str]) -> pd.DataFrame:
+    if not translation:
+        df = df.rename(columns={col: _to_snake_case(col) for col in df.columns})
+        return df
+    rename_map = {col: translation.get(col, translation.get(col.lower(), _to_snake_case(col))) for col in df.columns}
+    return df.rename(columns=rename_map)
+
+
+def _ensure_datetime(df: pd.DataFrame) -> pd.DataFrame:
+    if "date" in df.columns:
+        df["date"] = pd.to_datetime(df["date"], errors="coerce")
+        df = df.dropna(subset=["date"])
+    return df
+
+
+def _ensure_stock_id(df: pd.DataFrame) -> pd.DataFrame:
+    if "stock_id" in df.columns:
+        df["stock_id"] = df["stock_id"].astype(str)
+    return df
+
+
+def _numeric(df: pd.DataFrame, columns: Iterable[str]) -> None:
+    for column in columns:
+        if column in df.columns:
+            df[column] = pd.to_numeric(df[column], errors="coerce")
+
+
+def fetch_stock_info(client: APIClient) -> pd.DataFrame:
+    """取得基本股名表。"""
+
+    try:
+        df = client.fetch_dataset("TaiwanStockInfo", None, None, None)
+    except Exception as exc:  # noqa: BLE001 - 外部 API 可能失敗
+        LOGGER.warning("TaiwanStockInfo 抓取失敗：%s", exc)
+        return pd.DataFrame(columns=["stock_id", "industry_category", "stock_name"])
+
+    translation = client.try_translation("TaiwanStockInfo")
+    df = _apply_translation(df, translation)
+    df = _ensure_stock_id(df)
+    return df.drop_duplicates(subset=["stock_id"])
+
+
+def fetch_trading_calendar(client: APIClient, start: str, end: str) -> pd.DataFrame:
+    """取得交易日曆。"""
+
+    try:
+        calendar = client.fetch_dataset("TaiwanStockTradingDate", None, start, end)
+    except Exception as exc:  # noqa: BLE001
+        LOGGER.warning("TaiwanStockTradingDate 抓取失敗：%s", exc)
+        return pd.DataFrame(columns=["date", "is_trading_day"])
+
+    translation = client.try_translation("TaiwanStockTradingDate")
+    calendar = _apply_translation(calendar, translation)
+    calendar = _ensure_datetime(calendar)
+    if "is_trading_day" not in calendar.columns and "trading" in calendar.columns:
+        calendar = calendar.rename(columns={"trading": "is_trading_day"})
+    if "is_trading_day" in calendar.columns:
+        calendar["is_trading_day"] = calendar["is_trading_day"].astype(int)
+    calendar = calendar.sort_values("date").reset_index(drop=True)
+    return calendar
+
+
+def _prepare_price_frame(df: pd.DataFrame) -> pd.DataFrame:
+    rename_map = {
+        "max": "high",
+        "min": "low",
+        "trading_volume": "volume",
+        "trading_value": "turnover",
+        "trading_money": "turnover",
+        "trading_turnover": "transactions",
+        "spread": "price_change",
+    }
+    df = df.rename(columns=rename_map)
+    base_columns = ["date", "stock_id", "open", "high", "low", "close", "volume", "turnover"]
+    for column in base_columns:
+        if column not in df.columns:
+            df[column] = np.nan
+    numeric_columns = [
+        "open",
+        "high",
+        "low",
+        "close",
+        "volume",
+        "turnover",
+        "transactions",
+        "price_change",
+    ]
+    _numeric(df, numeric_columns)
+    df = df.sort_values(["stock_id", "date"]).reset_index(drop=True)
+    if "close" in df.columns:
+        df["return"] = df.groupby("stock_id")["close"].pct_change()
+    return df
+
+
+def fetch_price_dataset(
+    stocks: Sequence[str],
+    client: APIClient,
+    dataset: str,
+    start: str,
+    end: str,
+) -> pd.DataFrame:
+    """共用的價格資料抓取函式。"""
+
+    frames: List[pd.DataFrame] = []
+    translation = client.try_translation(dataset)
+    for stock in stocks:
+        try:
+            df = client.fetch_dataset(dataset, stock, start, end)
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.warning("%s 抓取失敗：%s %s", dataset, stock, exc)
+            continue
+        if df.empty:
+            continue
+        df = _apply_translation(df, translation)
+        df = _ensure_datetime(df)
+        df = _ensure_stock_id(df)
+        frames.append(df)
+    if not frames:
+        return pd.DataFrame(columns=["date", "stock_id"])
+    combined = pd.concat(frames, ignore_index=True)
+    combined = _prepare_price_frame(combined)
+    return combined
+
+
+def fetch_technical_data(
+    stocks: Sequence[str],
+    since: str,
+    client: APIClient,
+    end_date: Optional[str] = None,
+) -> Dict[str, pd.DataFrame]:
+    """抓取主要技術面資料集。"""
+
+    end = end_date or date.today().strftime("%Y-%m-%d")
+    LOGGER.info("抓取技術面資料：股票數量=%s", len(stocks))
+
+    results: Dict[str, pd.DataFrame] = {}
+    results["TaiwanStockInfo"] = fetch_stock_info(client)
+    results["TaiwanStockTradingDate"] = fetch_trading_calendar(client, since, end)
+    results["TaiwanStockPrice"] = fetch_price_dataset(stocks, client, "TaiwanStockPrice", since, end)
+    results["TaiwanStockPriceAdj"] = fetch_price_dataset(stocks, client, "TaiwanStockPriceAdj", since, end)
+    return results
+
+
+__all__ = ["fetch_technical_data"]


### PR DESCRIPTION
## Summary
* add a dedicated APIClient wrapper that handles FinMind authentication fallbacks, retries, and metadata helpers so downstream modules can consistently request datasets
* implement technical, fundamental, chip, and derivative fetchers that normalize column names and return vertically concatenated DataFrames for raw exports
* build a new enrichment pipeline that aligns datasets on the trading calendar, forward fills eligible fundamentals/chip fields, derives daily analytics, and expose everything through an updated CLI that writes raw and clean CSV outputs

## Testing
* pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce81ffdcc88324bee0fc03a8025c3b