### PR TITLE
Add price-based 10Y MA fallback and CLI improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,19 +41,17 @@ pip install pandas requests pyarrow
 
 ```bash
 python main.py \
-  --token <你的 FinMind token> \
-  --stocks 2330,2317,2454 \
-  --start 2024-01-01 \
+  --tickers 2330,2317,2454 \
+  --since 2024-01-01 \
   --end 2024-12-31 \
-  --datasets TaiwanStockPrice,TaiwanStockInstitutionalInvestorsBuySell \
   --outdir ./output \
-  --merge
+  --finmind-token "$FINMIND_TOKEN"
 ```
 
 完成後會生成下列檔案：
 
 * `output/_merged.csv`
-* `output/_clean_daily_wide.csv`
+* `output/_clean_daily_wide.csv`（含 `MA10Y` 欄位，預設由調整股價計算）
 * `output/_clean_daily_wide_min.csv`
 
 ### 3. 擴充基本面與市場熱度欄位（選用）
@@ -65,6 +63,40 @@ python -m finmind_fetch \
   --since 2024-01-01 \
   --finmind-token $FINMIND_TOKEN
 ```
+
+上述流程將優先採用 `FINMIND_TOKEN` 環境變數。若 CLI 未提供或傳入空白 token，也會自動回退至環境變數；當兩者皆缺少時，流程仍會執行，僅使用註冊等級可存取的資料集。
+
+## 🖥️ CLI 使用範例
+
+### PowerShell（支援反引號換行）
+
+```powershell
+$env:FINMIND_TOKEN = "<YOUR_TOKEN>"
+python .\main.py `
+  --tickers 1519,2379,2383,2454,3035,3293,6231,6643,8358,8932 `
+  --since 2024-01-01 `
+  --end 2024-12-31 `
+  --outdir .\finmind_out
+```
+
+### 啟用十年線 API（需 Sponsor，失敗時自動改用股價計算）
+
+```powershell
+python .\main.py `
+  --tickers 2454 `
+  --since 2014-01-01 `
+  --use-10y-api `
+  --outdir .\finmind_out
+```
+
+### Windows CMD（單行，不建議換行）
+
+```cmd
+set FINMIND_TOKEN=<YOUR_TOKEN>
+python main.py --tickers 2454 --since 2014-01-01 --outdir finmind_out
+```
+
+> 預設不呼叫 `TaiwanStock10Year` dataset；若加上 `--use-10y-api` 但權限不足，程式會於 log 中提示並回退至依股價推估的十年線 (`MA10Y`)。
 
 執行後將透過 FinMind API 取得月營收與財報資料，自動計算 `revenue_yoy`、`revenue_mom`、`eps`、`eps_ttm` 等基本面欄位，以及 `turnover_rank_pct`、`volume_rank_pct`、`volume_ratio`、`turnover_change_5d`、`transactions_change_5d` 等資金熱度指標。結果會回寫至 `_clean_daily_wide.csv` 與 `_clean_daily_wide_min.csv`。
 

--- a/finmind_etl/cli.py
+++ b/finmind_etl/cli.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import argparse
 import logging
+import os
 from pathlib import Path
-from typing import Iterable, List
+from typing import Dict, Iterable, List
 
 import pandas as pd
 
@@ -14,6 +15,7 @@ from .chip import fetch_chip_data
 from .fundamentals import fetch_fundamental_data
 from .merge import build_minimal_view, merge_all
 from .technical import fetch_technical_data
+from .finmind_api import compute_ma_from_price, fetch_stock_price, try_fetch_10y_api
 
 LOGGER = logging.getLogger("finmind_etl.cli")
 
@@ -34,12 +36,28 @@ def parse_arguments(argv: Iterable[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--finmind-token", dest="token", help="FinMind API token")
     parser.add_argument("--outdir", default="./finmind_out", help="輸出資料夾")
     parser.add_argument("--end", help="結束日期，預設為今日")
+    parser.add_argument(
+        "--use-10y-api",
+        action="store_true",
+        help="啟用 TaiwanStock10Year API（需 Sponsor 等級，失敗將自動回退）",
+    )
     return parser.parse_args(argv)
 
 
 def _parse_tickers(value: str) -> List[str]:
     tickers = [item.strip() for item in value.split(",") if item.strip()]
     return [ticker.zfill(4) for ticker in tickers]
+
+
+def _resolve_token(cli_token: str | None) -> str | None:
+    candidates = [cli_token, os.getenv("FINMIND_TOKEN")]
+    for value in candidates:
+        if value is None:
+            continue
+        trimmed = value.strip()
+        if trimmed:
+            return trimmed
+    return None
 
 
 def _write_dataframe(df: pd.DataFrame, path: Path) -> None:
@@ -51,6 +69,88 @@ def _write_dataframe(df: pd.DataFrame, path: Path) -> None:
     LOGGER.info("輸出 %s 筆資料至 %s", len(export), path)
 
 
+def _select_price_frame(
+    ticker: str,
+    technical: Dict[str, "DatasetResult"],
+    since: str,
+    end: str | None,
+    token: str | None,
+) -> pd.DataFrame:
+    from .datasets import DatasetResult  # 延遲匯入避免循環
+
+    def _filter_and_prepare(result: DatasetResult | None, column: str) -> pd.DataFrame:
+        if result is None or result.clean.empty:
+            return pd.DataFrame()
+        df = result.clean.copy()
+        df["stock_id"] = df["stock_id"].astype(str).str.strip()
+        subset = df[df["stock_id"] == ticker]
+        if subset.empty:
+            return pd.DataFrame()
+        if column in subset.columns:
+            subset["close"] = pd.to_numeric(subset[column], errors="coerce")
+        elif "close" in subset.columns:
+            subset["close"] = pd.to_numeric(subset["close"], errors="coerce")
+        else:
+            subset["close"] = pd.NA
+        return subset
+
+    price_adj = technical.get("TaiwanStockPriceAdj")
+    prepared = _filter_and_prepare(price_adj, "adj_close")
+    if not prepared.empty:
+        return prepared
+
+    price = technical.get("TaiwanStockPrice")
+    prepared = _filter_and_prepare(price, "close")
+    if not prepared.empty:
+        return prepared
+
+    fallback = fetch_stock_price(ticker, since, end, token, use_adj=True)
+    if fallback.empty:
+        return fallback
+    fallback["stock_id"] = fallback.get("stock_id", ticker)
+    return fallback
+
+
+def _build_ma10y_map(
+    tickers: List[str],
+    technical: Dict[str, "DatasetResult"],
+    since: str,
+    end: str | None,
+    token: str | None,
+    use_api: bool,
+) -> pd.DataFrame:
+    frames: List[pd.DataFrame] = []
+
+    for ticker in tickers:
+        ma_frame: pd.DataFrame | None = None
+        if use_api:
+            ma_frame = try_fetch_10y_api(ticker, since, end, token)
+
+        if ma_frame is None:
+            price_frame = _select_price_frame(ticker, technical, since, end, token)
+            if price_frame.empty:
+                LOGGER.warning("Ticker %s 無法取得股價資料，MA10Y 欄位將為空。", ticker)
+                continue
+            ma_frame = compute_ma_from_price(price_frame, price_col="close")
+
+        if ma_frame is None or ma_frame.empty:
+            continue
+
+        ma_frame = ma_frame.copy()
+        ma_frame["stock_id"] = ma_frame.get("stock_id", ticker)
+        ma_frame["stock_id"] = ma_frame["stock_id"].astype(str).str.strip()
+        frames.append(ma_frame[["stock_id", "date", "MA10Y"]])
+
+    if not frames:
+        return pd.DataFrame(columns=["stock_id", "date", "MA10Y"])
+
+    merged = pd.concat(frames, ignore_index=True)
+    merged["date"] = pd.to_datetime(merged["date"], errors="coerce")
+    merged = merged.dropna(subset=["date"])
+    merged = merged.sort_values(["stock_id", "date"]).reset_index(drop=True)
+    return merged.drop_duplicates(subset=["stock_id", "date"], keep="last")
+
+
 def main(argv: Iterable[str] | None = None) -> None:
     args = parse_arguments(argv)
     configure_logging()
@@ -60,11 +160,17 @@ def main(argv: Iterable[str] | None = None) -> None:
         raise SystemExit("請至少提供一檔股票代號")
 
     LOGGER.info("目標股票：%s", tickers)
-    client = APIClient(token=args.token)
+    token = _resolve_token(args.token)
+    if token is None and args.token and not args.token.strip():
+        LOGGER.info("CLI 提供的 token 為空字串，將改用環境變數。")
+    if token is None and os.getenv("FINMIND_TOKEN"):
+        LOGGER.info("使用環境變數 FINMIND_TOKEN 中的 token。")
+    client = APIClient(token=token)
 
     technical = fetch_technical_data(tickers, args.since, client, end_date=args.end)
     fundamentals = fetch_fundamental_data(tickers, args.since, client, end_date=args.end)
     chip = fetch_chip_data(tickers, args.since, client, end_date=args.end)
+    ma10y_map = _build_ma10y_map(tickers, technical, args.since, args.end, token, args.use_10y_api)
     outdir = Path(args.outdir)
     outdir.mkdir(parents=True, exist_ok=True)
 
@@ -77,6 +183,12 @@ def main(argv: Iterable[str] | None = None) -> None:
     if daily_wide.empty:
         LOGGER.warning("合併後資料為空，請檢查輸入參數或 API 回應。")
         return
+
+    if ma10y_map.empty:
+        daily_wide["MA10Y"] = pd.NA
+    else:
+        daily_wide = daily_wide.merge(ma10y_map, on=["stock_id", "date"], how="left")
+        daily_wide = daily_wide.sort_values(["date", "stock_id"]).reset_index(drop=True)
 
     wide_path = outdir / "_clean_daily_wide.csv"
     _write_dataframe(daily_wide, wide_path)

--- a/finmind_etl/datasets.py
+++ b/finmind_etl/datasets.py
@@ -648,15 +648,6 @@ TECHNICAL_SPECS: List[DatasetSpec] = [
         description="Total return index",
     ),
     DatasetSpec(
-        name="TaiwanStock10Year",
-        category="technical",
-        cleaner=_clean_stock_10year,
-        numeric_fields=("avg_price_10y",),
-        forward_fill=True,
-        required_fields=("date", "stock_id"),
-        description="Ten year moving averages",
-    ),
-    DatasetSpec(
         name="TaiwanStockKBar",
         category="technical",
         include_in_wide=False,

--- a/finmind_etl/finmind_api.py
+++ b/finmind_etl/finmind_api.py
@@ -1,0 +1,288 @@
+"""FinMind API 輔助函式：處理資料抓取與十年線計算。"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Iterable
+
+import pandas as pd
+import requests
+
+FINMIND_API = "https://api.finmindtrade.com/api/v4/data"
+DEFAULT_TIMEOUT = 20
+
+LOGGER = logging.getLogger("finmind_etl.finmind_api")
+
+
+def _normalise_symbol(symbol: str | None) -> str:
+    text = str(symbol or "").strip()
+    if text.isdigit():
+        return text.zfill(4)
+    return text
+
+
+def _build_attempts(token: str | None, params: Dict[str, Any]) -> Iterable[tuple[Dict[str, str], Dict[str, Any]]]:
+    query = {key: value for key, value in params.items() if value not in (None, "")}
+    if token:
+        headers = {"Authorization": f"Bearer {token}"}
+        query_without_token = dict(query)
+        query_without_token.pop("token", None)
+        yield headers, query_without_token
+        query_with_token = dict(query_without_token)
+        query_with_token["token"] = token
+        yield {}, query_with_token
+    else:
+        yield {}, query
+
+
+def _parse_response(dataset: str, response: requests.Response) -> tuple[pd.DataFrame | None, str | None, str | None]:
+    """解析 FinMind 回應並回傳結果或錯誤資訊。"""
+
+    error_message: str | None = None
+    level_required: str | None = None
+
+    if response.status_code != 200:
+        try:
+            payload = response.json()
+            error_message = str(payload.get("msg", ""))
+        except ValueError:
+            error_message = response.text.strip()
+
+        if response.status_code == 400 and error_message and "Your level is register" in error_message:
+            level_required = "Sponsor"
+            LOGGER.warning(
+                "Dataset %s requires higher level (Sponsor). Fallback to price-based MA10Y.",
+                dataset,
+            )
+        else:
+            LOGGER.warning(
+                "Dataset %s request failed: HTTP %s %s",
+                dataset,
+                response.status_code,
+                error_message or response.text,
+            )
+        return None, error_message, level_required
+
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        LOGGER.warning("Dataset %s JSON decode error: %s", dataset, exc)
+        return None, str(exc), None
+
+    status = payload.get("status")
+    if status != 200:
+        message = str(payload.get("msg", ""))
+        if "Your level is register" in message:
+            LOGGER.warning(
+                "Dataset %s requires higher level (Sponsor). Fallback to price-based MA10Y.",
+                dataset,
+            )
+            return None, message, "Sponsor"
+        LOGGER.warning("Dataset %s request failed: status=%s msg=%s", dataset, status, message)
+        return None, message, None
+
+    data = payload.get("data")
+    if not data:
+        return pd.DataFrame(), None, None
+
+    df = pd.DataFrame(data)
+    if "date" in df.columns:
+        df["date"] = pd.to_datetime(df["date"], errors="coerce")
+    if "stock_id" in df.columns:
+        df["stock_id"] = df["stock_id"].astype(str).str.strip()
+    df = df.sort_values([col for col in ["stock_id", "date"] if col in df.columns]).reset_index(drop=True)
+    return df, None, None
+
+
+def fetch_dataset(dataset: str, params: dict[str, Any]) -> pd.DataFrame:
+    """以通用方式呼叫 FinMind v4 API。"""
+
+    effective = dict(params)
+    token = effective.pop("token", None)
+    query = {"dataset": dataset, **effective}
+
+    last_error: str | None = None
+    level_required: str | None = None
+
+    for headers, query_params in _build_attempts(token, query):
+        try:
+            response = requests.get(FINMIND_API, params=query_params, headers=headers, timeout=DEFAULT_TIMEOUT)
+        except requests.RequestException as exc:  # noqa: PERF203 - 需完整捕捉
+            last_error = str(exc)
+            LOGGER.warning("Dataset %s request failed: %s", dataset, exc)
+            continue
+
+        parsed, message, level = _parse_response(dataset, response)
+        if parsed is not None:
+            return parsed
+
+        last_error = message
+        if level is not None:
+            level_required = level
+            break
+
+    df = pd.DataFrame()
+    if last_error:
+        df.attrs["error_message"] = last_error
+    if level_required:
+        df.attrs["level_required"] = level_required
+    return df
+
+
+def fetch_stock_price(
+    symbol: str,
+    start_date: str,
+    end_date: str | None,
+    token: str | None,
+    use_adj: bool = True,
+) -> pd.DataFrame:
+    """抓 TaiwanStockPriceAdj（預設）或 TaiwanStockPrice。"""
+
+    stock_id = _normalise_symbol(symbol)
+    dataset = "TaiwanStockPriceAdj" if use_adj else "TaiwanStockPrice"
+    df = fetch_dataset(
+        dataset,
+        {
+            "data_id": stock_id,
+            "start_date": start_date,
+            "end_date": end_date,
+            "token": token,
+        },
+    )
+
+    if df.empty:
+        return df
+
+    df = df.copy()
+    if "stock_id" not in df.columns:
+        df["stock_id"] = stock_id
+    df["stock_id"] = df["stock_id"].astype(str).str.strip().replace({"": stock_id})
+    if "date" in df.columns:
+        df["date"] = pd.to_datetime(df["date"], errors="coerce")
+
+    price_column = "adj_close" if use_adj and "adj_close" in df.columns else "close"
+    if price_column not in df.columns and "close" in df.columns:
+        price_column = "close"
+    df["close"] = pd.to_numeric(df.get(price_column), errors="coerce")
+    df = df.sort_values(["stock_id", "date"]).reset_index(drop=True)
+    df.attrs["symbol"] = stock_id
+    return df
+
+
+def try_fetch_10y_api(
+    symbol: str,
+    start_date: str,
+    end_date: str | None,
+    token: str | None,
+) -> pd.DataFrame | None:
+    """僅在使用者帶 --use-10y-api 時呼叫 TaiwanStock10Year。"""
+
+    stock_id = _normalise_symbol(symbol)
+    df = fetch_dataset(
+        "TaiwanStock10Year",
+        {
+            "data_id": stock_id,
+            "start_date": start_date,
+            "end_date": end_date,
+            "token": token,
+        },
+    )
+
+    if df.empty:
+        if df.attrs.get("level_required") == "Sponsor":
+            return None
+        error_message = df.attrs.get("error_message")
+        if error_message:
+            LOGGER.warning("TaiwanStock10Year 抓取失敗：%s", error_message)
+        else:
+            LOGGER.warning("TaiwanStock10Year 回傳空資料，改用股價推算。")
+        return None
+
+    rename_map = {}
+    for column in ("MA10Y", "avg_price_10y", "avg", "value", "avg_price"):
+        if column in df.columns:
+            rename_map[column] = "MA10Y"
+            break
+    df = df.rename(columns=rename_map)
+    if "MA10Y" not in df.columns:
+        LOGGER.warning("TaiwanStock10Year 回傳資料缺少十年線欄位，改用股價推算。")
+        return None
+
+    df = df.copy()
+    df["MA10Y"] = pd.to_numeric(df["MA10Y"], errors="coerce")
+    if "date" in df.columns:
+        df["date"] = pd.to_datetime(df["date"], errors="coerce")
+    if "stock_id" not in df.columns:
+        df["stock_id"] = stock_id
+    df["stock_id"] = df["stock_id"].astype(str).str.strip().replace({"": stock_id})
+    keep = ["stock_id", "date", "MA10Y"]
+    df = df[keep]
+    df = df.dropna(subset=["date"]).sort_values(["stock_id", "date"]).reset_index(drop=True)
+    return df
+
+
+def compute_ma_from_price(
+    df_price: pd.DataFrame,
+    window_days: int = 2400,
+    price_col: str = "close",
+) -> pd.DataFrame:
+    """從價格資料計算十年線。"""
+
+    if df_price is None or df_price.empty:
+        return pd.DataFrame(columns=["stock_id", "date", "MA10Y"])
+
+    df = df_price.copy()
+    if "date" not in df.columns:
+        return pd.DataFrame(columns=["stock_id", "date", "MA10Y"])
+
+    df["date"] = pd.to_datetime(df["date"], errors="coerce")
+    df = df.dropna(subset=["date"])
+    if df.empty:
+        return pd.DataFrame(columns=["stock_id", "date", "MA10Y"])
+
+    if "stock_id" not in df.columns:
+        symbol = df_price.attrs.get("symbol")
+        df["stock_id"] = _normalise_symbol(symbol or "")
+
+    df["stock_id"] = df["stock_id"].astype(str).str.strip().apply(_normalise_symbol)
+    df[price_col] = pd.to_numeric(df.get(price_col), errors="coerce")
+    df = df.sort_values(["stock_id", "date"]).reset_index(drop=True)
+
+    results: list[pd.DataFrame] = []
+    notified: set[str] = set()
+
+    for stock_id, group in df.groupby("stock_id", dropna=False):
+        if group.empty:
+            continue
+        sorted_group = group.sort_values("date")
+        rolling = sorted_group[price_col].rolling(window=window_days, min_periods=1).mean()
+        if len(sorted_group) < window_days:
+            since = sorted_group["date"].min()
+            symbol = _normalise_symbol(stock_id)
+            if symbol not in notified and pd.notna(since):
+                LOGGER.info(
+                    "Ticker %s has less than 10-year data since %s; MA10Y is an approximation.",
+                    symbol,
+                    since.strftime("%Y-%m-%d"),
+                )
+                notified.add(symbol)
+        result = pd.DataFrame({"stock_id": stock_id, "date": sorted_group["date"], "MA10Y": rolling})
+        results.append(result)
+
+    if not results:
+        return pd.DataFrame(columns=["stock_id", "date", "MA10Y"])
+
+    combined = pd.concat(results, ignore_index=True)
+    combined["stock_id"] = combined["stock_id"].astype(str).str.strip().apply(_normalise_symbol)
+    combined = combined.sort_values(["stock_id", "date"]).reset_index(drop=True)
+    return combined
+
+
+__all__ = [
+    "FINMIND_API",
+    "fetch_dataset",
+    "fetch_stock_price",
+    "try_fetch_10y_api",
+    "compute_ma_from_price",
+]
+

--- a/finmind_etl/merge.py
+++ b/finmind_etl/merge.py
@@ -92,6 +92,7 @@ def build_minimal_view(df: pd.DataFrame) -> pd.DataFrame:
         "high",
         "low",
         "close",
+        "MA10Y",
         "volume",
         "turnover",
         "return",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pandas
+requests
+python-dateutil


### PR DESCRIPTION
## Summary
- add dedicated helpers for FinMind dataset fetching and price-based 10Y moving average calculation
- update the CLI to resolve tokens from the environment, optionally call the 10-year API, and merge MA10Y into outputs
- refresh the README with new usage examples and add a requirements.txt listing runtime dependencies

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf8edcfe7083249c13b2a411f9b2f1