### PR TITLE
fix: prepercentiled mode + dynamic weighting + industry_col support

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,3 +137,12 @@ python -m finmind_etl scan-market --features finmind_out/features_snapshot.csv -
 python -m finmind_etl report-watchlist --features finmind_out/features_snapshot.csv --watchlist watchlist.csv --output finmind_out/watchlist_deep
 ```
 - `watchlist.csv` 需要一欄 `stock_id`
+
+### 分數計算模式
+- `use_prepercentiled=true`：`features` 直接提供 `score_*`（0–100）欄位，四大面向個別取平均後，再由**動態權重**合成總分（僅針對有值的面向重新正規化權重）。
+- `use_prepercentiled=false`：以原始特徵跑 winsorize →（選擇性）產業中性化 → percentile → 面向平均 → 動態權重總分，與舊版流程兼容。
+- 產業欄位由 `industry_col` 指定；若該欄不存在會改用 `industry` 或 `industry_category` 自動對齊。
+
+### NaN 處理
+- 單一面向缺值時，該面向的分數顯示為 NaN，總分會依照其他有值的面向重新正規化權重後加總，不會整列 NaN。
+- 報表會同時輸出 `_diag_missing_features.csv`，列出每個面向缺少的欄位與缺失率，方便追蹤資料品質。

--- a/finmind_etl/cli_extras.py
+++ b/finmind_etl/cli_extras.py
@@ -1,71 +1,182 @@
 from __future__ import annotations
-
 import argparse
-from pathlib import Path
-from typing import Any, Dict
-
 import pandas as pd
-
-try:  # pragma: no cover - optional dependency guard
-    import yaml
-except ImportError:  # pragma: no cover - runtime check
-    yaml = None  # type: ignore[assignment]
-
+from pathlib import Path
 from .reports.market_scan import run_market_scan
 from .reports.watchlist_deep import run_watchlist_report
+
+try:  # optional dependency
+    import yaml  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover
+    yaml = None  # type: ignore
 
 DEFAULT_FEATURES = "finmind_out/features_snapshot.csv"
 
 
-def _load_yaml(path: str | Path) -> Dict[str, Any]:
-    if yaml is None:
-        raise SystemExit("請先安裝 pyyaml：pip install pyyaml")
-    return yaml.safe_load(Path(path).read_text(encoding="utf-8"))
+def _parse_scalar(value: str):
+    lower = value.lower()
+    if lower == "true":
+        return True
+    if lower == "false":
+        return False
+    if lower in {"null", "none"}:
+        return None
+    # numbers
+    try:
+        if any(ch in value for ch in (".", "e", "E")):
+            return float(value)
+        return int(value)
+    except ValueError:
+        pass
+    if (value.startswith("\"") and value.endswith("\"")) or (value.startswith("'") and value.endswith("'")):
+        return value[1:-1]
+    return value
 
 
-def cmd_scan_market(args: argparse.Namespace) -> None:
+def _parse_inline_list(value: str):
+    inner = value.strip()[1:-1].strip()
+    if not inner:
+        return []
+    parts = [p.strip() for p in inner.split(",")]
+    return [_parse_scalar(p) for p in parts]
+
+
+def _minimal_yaml_load(text: str) -> dict:
+    lines = text.splitlines()
+
+    def parse_block(index: int, indent: int):
+        data = {}
+        i = index
+        while i < len(lines):
+            raw = lines[i]
+            stripped = raw.strip()
+            if not stripped or stripped.startswith("#"):
+                i += 1
+                continue
+            current_indent = len(raw) - len(raw.lstrip(" "))
+            if current_indent < indent:
+                break
+            if stripped.startswith("- "):
+                raise ValueError("Unexpected list item without key context")
+            if ":" not in stripped:
+                i += 1
+                continue
+            key, rest = stripped.split(":", 1)
+            key = key.strip()
+            rest = rest.strip()
+            if rest:
+                if rest.startswith("[") and rest.endswith("]"):
+                    data[key] = _parse_inline_list(rest)
+                else:
+                    data[key] = _parse_scalar(rest)
+                i += 1
+                continue
+            # lookahead for list or nested block
+            i += 1
+            # skip blank/comment lines when determining next item
+            while i < len(lines) and (not lines[i].strip() or lines[i].strip().startswith("#")):
+                i += 1
+            if i < len(lines) and lines[i].lstrip().startswith("- "):
+                lst, i = parse_list(i, indent + 2)
+                data[key] = lst
+            else:
+                sub, i = parse_block(i, indent + 2)
+                data[key] = sub
+        return data, i
+
+    def parse_list(index: int, indent: int):
+        items = []
+        i = index
+        while i < len(lines):
+            raw = lines[i]
+            stripped = raw.strip()
+            if not stripped or stripped.startswith("#"):
+                i += 1
+                continue
+            current_indent = len(raw) - len(raw.lstrip(" "))
+            if current_indent < indent:
+                break
+            if not stripped.startswith("- "):
+                break
+            item = stripped[2:].strip()
+            if item.startswith("[") and item.endswith("]"):
+                items.append(_parse_inline_list(item))
+                i += 1
+            elif item and ":" in item:
+                # list item with inline dict ("- key: value")
+                sub_lines = [" " * (indent + 2) + item]
+                j = i + 1
+                while j < len(lines):
+                    nxt = lines[j]
+                    nxt_strip = nxt.strip()
+                    nxt_indent = len(nxt) - len(nxt.lstrip(" "))
+                    if nxt_indent <= indent or (nxt_strip and nxt_strip.startswith("- ")):
+                        break
+                    sub_lines.append(nxt)
+                    j += 1
+                sub_text = "\n".join(sub_lines)
+                items.append(_minimal_yaml_load(sub_text))
+                i = j
+            else:
+                items.append(_parse_scalar(item))
+                i += 1
+        return items, i
+
+    data, _ = parse_block(0, 0)
+    return data
+
+
+def _load_yaml(p: str) -> dict:
+    text = Path(p).read_text(encoding="utf-8")
+    if yaml is not None:  # pragma: no branch
+        return yaml.safe_load(text)
+    return _minimal_yaml_load(text)
+
+
+def _diag_missing(features_df: pd.DataFrame, config: dict, out_dir: str):
+    feats_cfg = config.get("features", {})
+    recs = []
+    for pillar, cols in feats_cfg.items():
+        for c in cols:
+            exists = c in features_df.columns
+            miss_rate = float(features_df[c].isna().mean()) if exists else 1.0
+            recs.append({"pillar": pillar, "column": c, "exists": exists, "missing_rate": round(miss_rate, 4)})
+    if recs:
+        out = Path(out_dir)
+        out.mkdir(parents=True, exist_ok=True)
+        pd.DataFrame(recs).to_csv(out/"_diag_missing_features.csv", index=False, encoding="utf-8")
+
+
+def cmd_scan_market(args: argparse.Namespace):
     config = _load_yaml(args.scoring)
     feats_path = Path(args.features or DEFAULT_FEATURES)
     if not feats_path.exists():
         raise SystemExit(f"features 檔不存在：{feats_path}")
     feats = pd.read_csv(feats_path)
-    universe = args.universe or config.get("universe", {}).get("default", "market_neutralized_by_industry")
-    result = run_market_scan(feats, config, universe, args.output)
-    print(f"已產出全市場粗篩報告：{result}")
+    _diag_missing(feats, config, args.output)
+    run_market_scan(feats, config, args.universe, args.output)
 
 
-def cmd_report_watchlist(args: argparse.Namespace) -> None:
+def cmd_report_watchlist(args: argparse.Namespace):
     config = _load_yaml(args.scoring)
     feats = pd.read_csv(args.features)
-    watchlist_path = Path(args.watchlist)
-    if not watchlist_path.exists():
-        raise SystemExit(f"watchlist 檔不存在：{watchlist_path}")
-    watchlist_df = pd.read_csv(watchlist_path)
-    if "stock_id" not in watchlist_df.columns:
-        raise SystemExit("watchlist.csv 需要包含 stock_id 欄位")
-    wl = set(watchlist_df["stock_id"].astype(str))
+    wl = set(pd.read_csv(args.watchlist)["stock_id"].astype(str))
     feats = feats[feats["stock_id"].astype(str).isin(wl)].copy()
-    if feats.empty:
-        raise SystemExit("features 內無符合 watchlist 的股票")
-    result = run_watchlist_report(feats, config, args.output)
-    print(f"已產出自選清單報告：{result}")
+    _diag_missing(feats, config, args.output)
+    run_watchlist_report(feats, config, args.output)
 
 
-def register_subcommands(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
+def register_subcommands(subparsers):
     sp = subparsers.add_parser("scan-market", help="全市場粗篩報告")
     sp.add_argument("--features", default=DEFAULT_FEATURES)
     sp.add_argument("--scoring", default="scoring.yml")
-    sp.add_argument(
-        "--universe",
-        default="market_neutralized_by_industry",
-        choices=["market_neutralized_by_industry", "industry", "watchlist", "market"],
-    )
+    sp.add_argument("--universe", default="market_neutralized_by_industry", choices=["market_neutralized_by_industry","industry","watchlist","market"])
     sp.add_argument("--output", default="finmind_out/market_scan")
     sp.set_defaults(func=cmd_scan_market)
 
     sp2 = subparsers.add_parser("report-watchlist", help="自選清單深度報告")
     sp2.add_argument("--features", required=True)
-    sp2.add_argument("--watchlist", required=True)
+    sp2.add_argument("--watchlist", required=True)  # CSV with stock_id column
     sp2.add_argument("--scoring", default="scoring.yml")
     sp2.add_argument("--output", default="finmind_out/watchlist_deep")
     sp2.set_defaults(func=cmd_report_watchlist)

--- a/finmind_etl/reports/market_scan.py
+++ b/finmind_etl/reports/market_scan.py
@@ -1,95 +1,23 @@
 from __future__ import annotations
-
-from pathlib import Path
-from typing import Iterable
-
 import pandas as pd
+from pathlib import Path
+from ..scoring_core import build_scores
 
-from ..scoring_core import combine_four_pillars, industry_neutralize, to_percentile, winsorize
-
-
-def _flatten_features(features_config: dict) -> list[str]:
-    cols: list[str] = []
-    for values in features_config.values():
-        cols.extend(values)
-    return cols
-
-
-def _ensure_basic_columns(df: pd.DataFrame) -> pd.DataFrame:
-    if "industry" not in df.columns and "industry_category" in df.columns:
-        df["industry"] = df["industry_category"]
-    if "stock_name" not in df.columns and "name" in df.columns:
-        df["stock_name"] = df["name"]
-    if "stock_id" in df.columns:
-        df["stock_id"] = df["stock_id"].astype(str)
-    if "industry" not in df.columns:
-        df["industry"] = ""
-    if "stock_name" not in df.columns:
-        df["stock_name"] = ""
-    return df
-
-
-def _rename_adj_percentiles(df: pd.DataFrame, feature_cols: Iterable[str]) -> None:
-    for col in feature_cols:
-        pct_col = f"{col}_adj_pct"
-        if pct_col in df.columns:
-            df[f"{col}_pct"] = df[pct_col]
-
+KEEP = ["stock_id","stock_name","industry","score_total","tech_score","chip_score","fund_score","risk_score"]
 
 def run_market_scan(features_df: pd.DataFrame, config: dict, universe: str, out_dir: str) -> dict:
-    out = Path(out_dir)
-    out.mkdir(parents=True, exist_ok=True)
+    outdir = Path(out_dir); outdir.mkdir(parents=True, exist_ok=True)
     feats = features_df.copy()
-    feats = _ensure_basic_columns(feats)
-
-    feature_cols = _flatten_features(config.get("features", {}))
-    existing_cols = [c for c in feature_cols if c in feats.columns]
-
-    norm_cfg = config.get("normalization", {})
-    if norm_cfg and existing_cols:
-        winsor_lo, winsor_hi = norm_cfg.get("winsorize_pct", [0.01, 0.99])
-        feats = winsorize(feats, existing_cols, winsor_lo, winsor_hi)
-
-    if universe == "market_neutralized_by_industry":
-        feats = industry_neutralize(feats, existing_cols, ind_col="industry")
-        adj_cols = [f"{c}_adj" for c in existing_cols if f"{c}_adj" in feats.columns]
-        feats = to_percentile(feats, adj_cols, by=None)
-        _rename_adj_percentiles(feats, existing_cols)
-    elif universe == "industry":
-        feats = to_percentile(feats, existing_cols, by="industry")
-    else:
-        feats = to_percentile(feats, existing_cols, by=None)
-
-    feats = combine_four_pillars(feats, config)
-
-    keep_cols = [
-        "stock_id",
-        "stock_name",
-        "industry",
-        "score_total",
-        "tech_score",
-        "chip_score",
-        "fund_score",
-        "risk_score",
-    ]
-    available_cols = [c for c in keep_cols if c in feats.columns]
-    if "score_total" not in available_cols and "score_total" in feats.columns:
-        available_cols.append("score_total")
-    result_df = feats[available_cols].sort_values("score_total", ascending=False)
-
-    csv_path = out / "market_scan_scores.csv"
-    result_df.to_csv(csv_path, index=False, encoding="utf-8")
-
-    md_path = out / "market_scan_report.md"
+    scored = build_scores(feats, config, universe=universe)
+    # 輸出
+    csv_path = outdir / "market_scan_scores.csv"
+    cols = [c for c in KEEP if c in scored.columns]
+    scored.loc[:, cols].sort_values("score_total", ascending=False).to_csv(csv_path, index=False, encoding="utf-8")
+    # 簡易 MD
+    md_path = outdir / "market_scan_report.md"
+    top = scored.loc[:, cols].sort_values("score_total", ascending=False).head(50)
     lines = ["# Market Scan (Top 50)\n"]
-    top_rows = result_df.head(50)
-    for _, row in top_rows.iterrows():
-        stock_id = row.get("stock_id", "")
-        stock_name = row.get("stock_name", "")
-        industry = row.get("industry", "")
-        total = row.get("score_total")
-        display = "NA" if pd.isna(total) else int(round(float(total)))
-        lines.append(f"- {stock_id} {stock_name} [{industry}] → {display}")
+    for _, r in top.iterrows():
+        lines.append(f"- {r.get('stock_id','?')} {r.get('stock_name','?')} [{r.get('industry','?')}] → {int(round(r.get('score_total', float('nan')) or 0,0))}")
     md_path.write_text("\n".join(lines), encoding="utf-8")
-
     return {"csv": str(csv_path), "md": str(md_path)}

--- a/finmind_etl/reports/watchlist_deep.py
+++ b/finmind_etl/reports/watchlist_deep.py
@@ -1,94 +1,20 @@
 from __future__ import annotations
-
-from pathlib import Path
-
 import pandas as pd
+from pathlib import Path
+from ..scoring_core import build_scores
 
-from ..scoring_core import combine_four_pillars, to_percentile, winsorize
-
-
-def _flatten_features(features_config: dict) -> list[str]:
-    cols: list[str] = []
-    for values in features_config.values():
-        cols.extend(values)
-    return cols
-
-
-def _ensure_basic_columns(df: pd.DataFrame) -> pd.DataFrame:
-    if "industry" not in df.columns and "industry_category" in df.columns:
-        df["industry"] = df["industry_category"]
-    if "stock_name" not in df.columns and "name" in df.columns:
-        df["stock_name"] = df["name"]
-    if "stock_id" in df.columns:
-        df["stock_id"] = df["stock_id"].astype(str)
-    if "industry" not in df.columns:
-        df["industry"] = ""
-    if "stock_name" not in df.columns:
-        df["stock_name"] = ""
-    return df
-
+KEEP = ["stock_id","stock_name","industry","score_total","tech_score","chip_score","fund_score","risk_score"]
 
 def run_watchlist_report(features_df: pd.DataFrame, config: dict, out_dir: str) -> dict:
-    out = Path(out_dir)
-    out.mkdir(parents=True, exist_ok=True)
-    feats = features_df.copy()
-    feats = _ensure_basic_columns(feats)
-
-    feature_cols = _flatten_features(config.get("features", {}))
-    existing_cols = [c for c in feature_cols if c in feats.columns]
-
-    norm_cfg = config.get("normalization", {})
-    if norm_cfg and existing_cols:
-        winsor_lo, winsor_hi = norm_cfg.get("winsorize_pct", [0.01, 0.99])
-        feats = winsorize(feats, existing_cols, winsor_lo, winsor_hi)
-
-    feats = to_percentile(feats, existing_cols, by=None)
-    feats = combine_four_pillars(feats, config)
-
-    keep_cols = [
-        "stock_id",
-        "stock_name",
-        "industry",
-        "score_total",
-        "tech_score",
-        "chip_score",
-        "fund_score",
-        "risk_score",
-    ]
-    available_cols = [c for c in keep_cols if c in feats.columns]
-    if "score_total" not in available_cols and "score_total" in feats.columns:
-        available_cols.append("score_total")
-    result_df = feats[available_cols].sort_values("score_total", ascending=False)
-
-    csv_path = out / "watchlist_scores.csv"
-    result_df.to_csv(csv_path, index=False, encoding="utf-8")
-
-    md_path = out / "watchlist_report.md"
+    outdir = Path(out_dir); outdir.mkdir(parents=True, exist_ok=True)
+    scored = build_scores(features_df.copy(), config, universe="watchlist")
+    csv_path = outdir / "watchlist_scores.csv"
+    cols = [c for c in KEEP if c in scored.columns]
+    scored.loc[:, cols].sort_values("score_total", ascending=False).to_csv(csv_path, index=False, encoding="utf-8")
+    md_path = outdir / "watchlist_report.md"
     lines = ["# Watchlist Deep Report\n"]
-    for _, row in result_df.iterrows():
-        stock_id = row.get("stock_id", "")
-        stock_name = row.get("stock_name", "")
-        industry = row.get("industry", "")
-        total = row.get("score_total")
-        tech = row.get("tech_score")
-        chip = row.get("chip_score")
-        fund = row.get("fund_score")
-        risk = row.get("risk_score")
-        total_display = "NA" if pd.isna(total) else int(round(float(total)))
-        tech_display = "NA" if pd.isna(tech) else f"{float(tech):.1f}"
-        chip_display = "NA" if pd.isna(chip) else f"{float(chip):.1f}"
-        fund_display = "NA" if pd.isna(fund) else f"{float(fund):.1f}"
-        risk_display = "NA" if pd.isna(risk) else f"{float(risk):.1f}"
-        lines.append(f"## {stock_id} {stock_name}  (Industry: {industry})")
-        lines.append(
-            "總分：{total}，技術/籌碼/基本/風險：{tech}/{chip}/{fund}/{risk}\n".format(
-                total=total_display,
-                tech=tech_display,
-                chip=chip_display,
-                fund=fund_display,
-                risk=risk_display,
-            )
-        )
+    for _, r in scored.loc[:, cols].sort_values("score_total", ascending=False).iterrows():
+        lines.append(f"## {r.get('stock_id','?')} {r.get('stock_name','?')}  (Industry: {r.get('industry','?')})")
+        lines.append(f"總分：{int(round(r.get('score_total', float('nan')) or 0,0))}，技術/籌碼/基本/風險：{(r.get('tech_score', float('nan')) or float('nan')):.1f}/{(r.get('chip_score', float('nan')) or float('nan')):.1f}/{(r.get('fund_score', float('nan')) or float('nan')):.1f}/{(r.get('risk_score', float('nan')) or float('nan')):.1f}\n")
     md_path.write_text("\n".join(lines), encoding="utf-8")
-
     return {"csv": str(csv_path), "md": str(md_path)}

--- a/finmind_etl/scoring_core.py
+++ b/finmind_etl/scoring_core.py
@@ -1,28 +1,71 @@
 from __future__ import annotations
-
 import numpy as np
 import pandas as pd
+from typing import Dict, List
 
+# ---- helpers ----
+
+def _get_industry_col(df: pd.DataFrame, cfg: dict) -> str:
+    col = cfg.get("industry_col", "industry")
+    if col not in df.columns:
+        # 常見別名：industry_category
+        if "industry" in df.columns:
+            return "industry"
+        if "industry_category" in df.columns:
+            # 建一個別名 column，讓後續 by="industry" 能使用
+            df["industry"] = df["industry_category"]
+            return "industry"
+        # fallback
+        df["industry"] = "UNKNOWN"
+        return "industry"
+    # 若設定是其他名稱，複製一份到 industry 以簡化後續 groupby
+    if col != "industry":
+        df["industry"] = df[col]
+    return "industry"
+
+
+def _mean_ignore_all_nan(df: pd.DataFrame, cols: List[str]) -> pd.Series:
+    cols = [c for c in cols if c in df.columns]
+    if not cols:
+        return pd.Series(np.nan, index=df.index)
+    # 全 NaN → 結果 NaN；否則平均非 NaN 值
+    s = df[cols].mean(axis=1, skipna=True)
+    all_nan_mask = df[cols].isna().all(axis=1)
+    s[all_nan_mask] = np.nan
+    return s
+
+
+def build_four_pillars_from_prepercentile(df: pd.DataFrame, cfg: dict) -> pd.DataFrame:
+    feats = cfg.get("features", {})
+    out = df.copy()
+    for pillar in ("tech","chip","fund","risk"):
+        cols = feats.get(pillar, [])
+        out[f"{pillar}_score"] = _mean_ignore_all_nan(out, cols)
+    return out
+
+
+def dynamic_weighted_total(df: pd.DataFrame, weights: Dict[str,float]) -> pd.Series:
+    # 對每一列：只對非 NaN 面向做加權，並把權重正規化到 1
+    pillars = ["tech","chip","fund","risk"]
+    w = np.array([weights.get(p, 0.0) for p in pillars], dtype=float)
+    mat = np.vstack([df[f"{p}_score"].to_numpy(dtype=float) for p in pillars])  # shape (4, N)
+    nan_mask = np.isnan(mat)
+    w_broadcast = w[:, None] * (~nan_mask)
+    denom = w_broadcast.sum(axis=0)
+    numer = np.nansum(mat * w[:, None], axis=0)
+    out = np.full_like(numer, np.nan)
+    nonzero = denom > 0
+    out[nonzero] = numer[nonzero] / denom[nonzero]
+    return pd.Series(out, index=df.index)
+
+# ---- optional raw→percentile 路徑（保留既有流程）----
 
 def mad(x: pd.Series) -> float:
     med = x.median()
     return (x - med).abs().median() or 1e-9
 
 
-def industry_neutralize(df: pd.DataFrame, cols: list[str], ind_col: str = "industry") -> pd.DataFrame:
-    if ind_col not in df.columns:
-        return df
-    g = df.groupby(ind_col)
-    for c in cols:
-        if c not in df.columns:
-            continue
-        med = g[c].transform("median")
-        m = g[c].transform(mad).replace(0, 1e-9)
-        df[c + "_adj"] = (df[c] - med) / m
-    return df
-
-
-def winsorize(df: pd.DataFrame, cols: list[str], lo: float = 0.01, hi: float = 0.99) -> pd.DataFrame:
+def winsorize(df: pd.DataFrame, cols: List[str], lo=0.01, hi=0.99) -> pd.DataFrame:
     for c in cols:
         if c not in df.columns:
             continue
@@ -32,33 +75,70 @@ def winsorize(df: pd.DataFrame, cols: list[str], lo: float = 0.01, hi: float = 0
     return df
 
 
-def to_percentile(df: pd.DataFrame, cols: list[str], by: str | None = None) -> pd.DataFrame:
-    valid_cols = [c for c in cols if c in df.columns]
-    if not valid_cols:
-        return df
-    if by and by in df.columns:
+def industry_neutralize(df: pd.DataFrame, cols: List[str], ind_col: str = "industry") -> pd.DataFrame:
+    g = df.groupby(ind_col)
+    for c in cols:
+        if c not in df.columns:
+            continue
+        med = g[c].transform("median")
+        m = g[c].transform(mad)
+        df[c + "_adj"] = (df[c] - med) / m
+    return df
+
+
+def to_percentile(df: pd.DataFrame, cols: List[str], by: str | None = None) -> pd.DataFrame:
+    if by:
         g = df.groupby(by)
-        for c in valid_cols:
+        for c in cols:
+            if c not in df.columns:
+                continue
             df[c + "_pct"] = g[c].rank(pct=True).mul(100)
     else:
-        for c in valid_cols:
+        for c in cols:
+            if c not in df.columns:
+                continue
             df[c + "_pct"] = df[c].rank(pct=True).mul(100)
     return df
 
 
-def combine_four_pillars(df: pd.DataFrame, config: dict) -> pd.DataFrame:
-    weights = config.get("weights", {})
-    feats = config.get("features", {})
-    for pillar in ("tech", "chip", "fund", "risk"):
-        cols = [f + "_pct" for f in feats.get(pillar, []) if f + "_pct" in df.columns]
-        if cols:
-            df[pillar + "_score"] = df[cols].mean(axis=1)
-        else:
-            df[pillar + "_score"] = np.nan
-    df["score_total"] = (
-        df.get("tech_score", np.nan) * weights.get("tech", 0)
-        + df.get("chip_score", np.nan) * weights.get("chip", 0)
-        + df.get("fund_score", np.nan) * weights.get("fund", 0)
-        + df.get("risk_score", np.nan) * weights.get("risk", 0)
-    )
-    return df
+def build_four_pillars_from_raw(df: pd.DataFrame, cfg: dict, universe: str) -> pd.DataFrame:
+    # 依舊使用原流程：winsorize -> (可選) industry neutralize -> percentile -> 平均
+    feats_cfg = cfg.get("features", {})
+    all_cols = sum([v for v in feats_cfg.values()], [])
+    out = df.copy()
+    norm = cfg.get("normalization", {})
+    lo, hi = (norm.get("winsorize_pct", [0.01, 0.99]) + [0,0])[:2]
+    out = winsorize(out, all_cols, lo, hi)
+
+    ind = _get_industry_col(out, cfg)
+    if universe == "market_neutralized_by_industry":
+        out = industry_neutralize(out, all_cols, ind_col=ind)
+        base_cols = [c + "_adj" for c in all_cols]
+        out = to_percentile(out, base_cols, by=None)
+        pct_cols = [c + "_adj_pct" for c in all_cols]
+    elif universe == "industry":
+        out = to_percentile(out, all_cols, by=ind)
+        pct_cols = [c + "_pct" for c in all_cols]
+    else:
+        out = to_percentile(out, all_cols, by=None)
+        pct_cols = [c + "_pct" for c in all_cols]
+
+    # 以 _pct 欄位平均成面向分數
+    for pillar in ("tech","chip","fund","risk"):
+        cols = [c + ("_adj_pct" if universe == "market_neutralized_by_industry" else "_pct") for c in feats_cfg.get(pillar, [])]
+        cols = [c for c in cols if c in out.columns]
+        out[f"{pillar}_score"] = _mean_ignore_all_nan(out, cols)
+    return out
+
+# ---- 統一入口 ----
+
+def build_scores(df: pd.DataFrame, cfg: dict, universe: str = "market_neutralized_by_industry") -> pd.DataFrame:
+    out = df.copy()
+    _get_industry_col(out, cfg)  # 確保有 industry 列
+    use_pre = bool(cfg.get("use_prepercentiled", False))
+    if use_pre:
+        out = build_four_pillars_from_prepercentile(out, cfg)
+    else:
+        out = build_four_pillars_from_raw(out, cfg, universe)
+    out["score_total"] = dynamic_weighted_total(out, cfg.get("weights", {}))
+    return out

--- a/scoring.yml
+++ b/scoring.yml
@@ -4,6 +4,9 @@ universe:
   min_universe_size: 25
   fallback_hierarchy: [subindustry, industry, sector, market]
 
+use_prepercentiled: true
+industry_col: industry_category
+
 normalization:
   method: industry_median_mad_then_market_rank
   winsorize_pct: [0.01, 0.99]
@@ -20,21 +23,21 @@ rounding:
 
 features:
   tech:
-    - ret_5d
-    - ret_20d
-    - rsi_14
-    - breakout_20d
-    - turnover_rate_20d
+    - score_tech_ret_5d
+    - score_tech_ret_20d
+    - score_tech_rsi14
+    - score_tech_breakout_20d
+    - score_tech_turnover_rate_20d
   chip:
-    - inst_net_buy_5d_ratio
-    - inst_consistency_20d
-    - margin_short_ratio_5d
-    - borrow_balance_chg_5d
+    - score_chip_inst_net_buy_5d_ratio
+    - score_chip_inst_consistency_20d
+    - score_chip_margin_short_ratio_5d
+    - score_chip_borrow_balance_chg_5d
   fund:
-    - revenue_yoy
-    - gross_margin_ttm
-    - roe_ttm
-    - op_margin_ttm
+    - score_fund_revenue_yoy
+    - score_fund_gross_margin_ttm
+    - score_fund_roe_ttm
+    - score_fund_op_margin_ttm
   risk:
-    - volatility_20d
-    - drawdown_60d
+    - score_risk_volatility_20d
+    - score_risk_drawdown_60d


### PR DESCRIPTION
## Summary
- add pre-percentile scoring path with dynamic weighting and industry column aliasing support
- switch market scan and watchlist reports to shared `build_scores` helper with config-driven behavior
- emit missing-feature diagnostics from the CLI and document the two scoring modes in the README

## Testing
- python -m finmind_etl scan-market --features finmind_scores/features_snapshot_20250919.csv --output finmind_reports/market_scan
- python -m finmind_etl report-watchlist --features finmind_scores/features_snapshot_20250919.csv --watchlist finmind_scores/scores_watchlist_20250919.csv --output finmind_reports/watchlist_deep


------
https://chatgpt.com/codex/tasks/task_e_68d106e04f5c83249197b1cdcfb26a8a